### PR TITLE
spec-v3 storage (roots/prefixes/scope) + @cached produce-or-load (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [0.18.0] - 2026-06-03 — spec-v3: storage roots/prefixes/scope + `@cached` produce-or-load
+
+Tracks datamanifest.toml **spec-v3**: a breaking behavioral revision of the storage model
+(it supersedes the spec-v2 model shipped in 0.17.0), plus the first half of the
+produce-or-load companion layer (`cache-produce`). `inspect` (the `cached.toml` index +
+maintenance) and `sync` are deferred to a follow-up.
+
+### Breaking — storage roots, prefixes, and scope
+
+- **Folder variables are bare top-level roots.** `$data` = `user_data_dir` (no `/Datasets`),
+  `$cache` = `user_cache_dir`, `$repo` = `<project_root>`. The lowercase content prefix
+  `datasets/` is applied by the layer, so a fetched dataset now lands at
+  `<root>/datasets/[<scope>/]<key>` (previously `…/Datasets/<key>`).
+- **New `DATAMANIFEST_DIR`** application base: when set, the default root of `$data` and
+  `$cache` (so everything lands under `$DATAMANIFEST_DIR/datasets/…` and `…/cached/…`).
+- **New `[_STORAGE._PREFIX]` / `[_STORAGE._SCOPE]`** tables and `DATAMANIFEST_PREFIX_<KIND>` /
+  `DATAMANIFEST_SCOPE_<KIND>` env vars. The **scope** partition controls sharing — empty for
+  `datasets` (shared), the project id for `cached` (project-isolated).
+- **`_PROFILE` is shelved**: reserved and preserved verbatim, no longer resolved (host
+  specificity is covered by the auto-matched `_HOST`).
+- **Read-only migration probe.** Existing 0.17.0 downloads under `…/datamanifest/Datasets`
+  still resolve (probed read-only, alongside the pre-v1.1 `~/.cache/Datasets` probe), so
+  nothing needs re-downloading; the probe is skipped when `DATAMANIFEST_DATA_DIR` or
+  `DATAMANIFEST_DIR` is set.
+
+### New — produce-or-load (`@cached`, `DataManifest.Cache`, capability `cache-produce`)
+
+- **`@cached cachetype=… key=(args -> (;…)) [ext=] [basename=] [version=] [store=]`** wraps a
+  **keyword-only** function with transparent disk caching: a `cached::Bool=true` escape
+  hatch, `_`-prefixed runtime knobs excluded from the hash, and a `_metadata_extras` audit
+  channel merged into the sidecar. (The macro is a non-normative ergonomic surface, ported
+  from LGMIO's `@cached`.)
+- **Parameter-hash keying.** The key is the SHA-256 of the **canonical JSON (JCS, RFC 8785)**
+  of the hash-affecting keyword parameters — cross-tool reproducible (reference vector
+  `83425a30…`). Hash inputs are restricted to strings/integers/booleans/arrays/objects;
+  **floats and nulls are a hard error**, and positional arguments are rejected (produced
+  datasets are keyword-only).
+- **Self-describing artifacts** at `<folder>/cached/[<scope>/]<cachetype>/[<version>/]<hash>/`:
+  the produced artifact plus `config.toml` (re-hashable key table + `[_META]`) and
+  `metadata.toml` (provenance: `created`/`tool`/`host`/`user`/`[git]`, write-if-absent),
+  materialized via the shared safe-materialization primitive. Default `store = "$cache"`.
+- **Artifact format registry.** `jls` (stdlib `Serialization`) is built in; other formats
+  (`nc`/`jld2`/…) register a `(save, load)` pair via `DataManifest.Cache.register_format!`
+  (the produced byte format is per-tool, not cross-language).
+- Conformance pin advanced to **`spec-v3`**; the `config_sidecar` fixture (param-hash
+  re-check) passes. `Dates` and `Serialization` are now declared dependencies.
+
 ## [0.17.0] - 2026-06-03 — spec-v2: `$`-folder-variable storage model
 
 Implements the spec-v2 storage-model revision (datamanifest.toml `spec-v2` /

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "DataManifest"
 uuid = "b8ee69ef-a20a-4d38-bceb-a68d72817f72"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Mahé Perrette <mahe.perrette@gmail.com>"]
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
@@ -19,7 +21,6 @@ julia = "1.10"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -30,4 +31,4 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [targets]
-test = ["CodecZlib", "CSV", "DataFrames", "Dates", "DimensionalData", "JSON", "NCDatasets", "OrderedCollections", "Parquet", "Tar", "YAML", "ZipFile"]
+test = ["CodecZlib", "CSV", "DataFrames", "DimensionalData", "JSON", "NCDatasets", "OrderedCollections", "Parquet", "Tar", "YAML", "ZipFile"]

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ Moves ref-shaped `julia=`/`loader=` fields and `[_LOADERS]` ref entries into `[<
 
 ## Storage model
 
-As of v0.17.0 (spec-v2), DataManifest uses a portable **`$`-folder-variable storage
-model** that keeps dataset paths consistent across languages:
+As of v0.18.0 (spec-v3), DataManifest uses a portable **`$`-folder-variable storage
+model**: a folder names a **bare root**, and the layer composes the rest of the path
+(`datasets/` for fetched data, `cached/` for produced artifacts) plus an optional **scope**:
 
 ```toml
 [_META]
@@ -117,42 +118,78 @@ schema = 1
 
 [_STORAGE]
 default = "$data"                # project-wide default selector (defaults to $data)
-scratch = "$TMPDIR/datasets"     # user-defined folder variable -> $scratch
+scratch = "$TMPDIR"              # user-defined folder variable (a bare root) -> $scratch
 
 [_STORAGE._HOST."login*.hpc.edu"]
-scratch = "/scratch/$USER/datasets"   # same variable, host-specific resolution
+scratch = "/scratch/$USER"       # same variable, host-specific resolution
+
+[_STORAGE._SCOPE]
+# datasets = "shared-pool"        # share fetched downloads within a group (default: shared)
 
 [my_dataset]
-store = "$cache"                 # put this dataset in the cache folder
+store = "$cache"                 # put this dataset under the cache folder's datasets/ tree
 uri   = "https://example.com/ds.nc"
 
 [big]
-store = "$cache/derived"         # sub-path: keyed under <cache_root>/derived/<key>
+store = "$cache/derived"         # sub-path: keyed under <cache>/derived/datasets/<key>
 uri   = "https://example.com/big.nc"
 ```
 
-A **folder** is referenced as a `$`-variable. Built-in folders resolve to
-language-independent default roots (Python's `platformdirs`):
+A **folder** is referenced as a `$`-variable resolving to a **bare top-level root**; the
+consuming layer adds `datasets/[<scope>/]` (fetch) or `cached/[<scope>/]` (produce) on top:
 
-| Folder   | Linux default                              |
-|----------|--------------------------------------------|
-| `$data`  | `$XDG_DATA_HOME/datamanifest/Datasets`     |
-| `$cache` | `$XDG_CACHE_HOME/datamanifest/Datasets`    |
-| `$repo`  | `<project_root>/datasets`                  |
+| Folder   | Bare root (Linux)                                   | Fetched dataset path           |
+|----------|-----------------------------------------------------|--------------------------------|
+| `$data`  | `$DATAMANIFEST_DIR` or `$XDG_DATA_HOME/datamanifest` | `<root>/datasets/<key>`        |
+| `$cache` | `$DATAMANIFEST_DIR` or `$XDG_CACHE_HOME/datamanifest`| `<root>/datasets/<key>`        |
+| `$repo`  | `<project_root>`                                    | `<root>/datasets/<key>`        |
 
 Any other `[_STORAGE]` key defines a **user folder** (`scratch = "…"` → `$scratch`).
-A dataset's `store` (and the `[_STORAGE].default`) is a `$`-folder **selector**,
-optionally with a sub-path (`$cache/derived`); `[_STORAGE]` values and `local_path`
-are **path expressions** that interpolate `$`-folder variables, `$USER`/env, and `~`.
+A dataset's `store` (and `[_STORAGE].default`) is a `$`-folder **selector**, optionally with
+a sub-path (`$cache/derived`); `[_STORAGE]` values and `local_path` are **path expressions**
+interpolating `$`-folder variables, `$USER`/env, and `~`. The `datasets` scope is empty by
+default (downloads are shared across projects); produced artifacts default to a
+project-isolated `cached` scope.
 
-> **Breaking change in v0.17.0**: bare store names (`store = "cache"`) are replaced
-> by `$`-references (`store = "$cache"`). Bare built-in names are auto-upgraded on
-> read (with a warning) and rewritten in `$`-form; the `mount` store was removed.
-> Default roots are unchanged from v0.16.0, so nothing needs re-downloading.
+> **Breaking change in v0.18.0 (spec-v3)**: folders are now bare roots and the layer applies
+> a lowercase `datasets/` prefix, so the fetched path moved `…/datamanifest/Datasets/<key>`
+> → `…/datamanifest/datasets/<key>`. Existing v0.17.0 downloads still resolve (read-only
+> probe); set `DATAMANIFEST_DIR` to put everything under one tree. `_PROFILE` is shelved
+> (preserved, not resolved) — use the auto-matched `_HOST`.
 
 Every folder variable resolves through one ladder:
-`DATAMANIFEST_<NAME>_DIR` env-var → `_PROFILE.<name>` (when `DATAMANIFEST_PROFILE`
-set) → first matching `_HOST.<glob>` → `[_STORAGE]` base → built-in default.
+`DATAMANIFEST_<NAME>_DIR` env-var → first matching `_HOST.<glob>` → `[_STORAGE]` base →
+built-in default. Prefixes/scopes resolve through `DATAMANIFEST_PREFIX_<KIND>` /
+`DATAMANIFEST_SCOPE_<KIND>` → `[_STORAGE._PREFIX | _SCOPE].<kind>` → default.
+
+## Produce-or-load caching (`@cached`)
+
+Beyond *fetching* declared datasets, DataManifest can *produce-or-load* — cache the result
+of a project function on disk, keyed by its parameters (spec-v3 `cache-produce`):
+
+```julia
+using DataManifest
+
+@cached cachetype="esm_anomaly" ext="jls" key=(a -> (; a.grid, a.skip_models)) function load_anomaly(;
+        grid::String = "5x5",
+        skip_models::Vector{String} = ["CESM.*", "FGOALS.*"],
+        _verbose::Bool = false)          # `_`-prefixed = runtime knob, excluded from the hash
+    # … expensive computation …
+    return result
+end
+
+load_anomaly(; grid="5x5")               # computes once, then loads from disk on repeat calls
+load_anomaly(; grid="5x5", cached=false) # escape hatch: run the body, no disk I/O
+```
+
+The cache key is the SHA-256 of the **canonical JSON** of the hash-affecting keyword
+parameters (cross-tool reproducible). Produced datasets are **keyword-only**; hash inputs
+must be strings/integers/booleans/arrays/objects — floats and nulls raise (pass a float as a
+string). Each artifact is self-describing — `config.toml` (the re-hashable key table) and
+`metadata.toml` (provenance) sit alongside it at
+`<$cache>/cached/<project>/<cachetype>/[<version>/]<hash>/`. `jls` (stdlib `Serialization`)
+is the built-in format; register others (`nc`, `jld2`, …) with
+`DataManifest.Cache.register_format!`.
 
 ## Parameterized bindings
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -89,21 +89,24 @@ It is also possible to provide a preferred name on disk via `key=...` to add. Th
 
 ## Storage model
 
-A dataset is materialized under a **folder**, referenced as a `$`-variable. Three
-folders are built-in; any other `[_STORAGE]` key defines a user folder:
+A dataset is materialized under a **folder**, referenced as a `$`-variable that resolves to
+a **bare top-level root**. The consuming layer composes the rest of the path: a `datasets/`
+content prefix (fetch) and an optional `scope` partition. Three folders are built-in; any
+other `[_STORAGE]` key defines a user folder:
 
-| Folder   | Meaning                                 | Default root (Linux)                          |
-|----------|-----------------------------------------|-----------------------------------------------|
-| `$data`  | persistent user data (default)          | `$XDG_DATA_HOME/datamanifest/Datasets`        |
-| `$cache` | OS-reclaimable cache *location*         | `$XDG_CACHE_HOME/datamanifest/Datasets`       |
-| `$repo`  | committed inside the project repository | `<project_root>/datasets`                     |
+| Folder   | Meaning                                 | Bare root (Linux)                                    |
+|----------|-----------------------------------------|------------------------------------------------------|
+| `$data`  | persistent user data (default)          | `$DATAMANIFEST_DIR` or `$XDG_DATA_HOME/datamanifest`  |
+| `$cache` | OS-reclaimable cache *location*         | `$DATAMANIFEST_DIR` or `$XDG_CACHE_HOME/datamanifest` |
+| `$repo`  | committed inside the project repository | `<project_root>`                                     |
 
-(The `mount` store of spec-v1.1 was removed in spec-v2.) Declare a dataset's
-folder with a `$`-**selector**, optionally with a sub-path:
+A fetched dataset lands at `<root>/datasets/[<scope>/]<key>`. (The `mount` store of
+spec-v1.1 was removed in spec-v2.) Declare a dataset's folder with a `$`-**selector**,
+optionally with a sub-path:
 
 ```toml
 [my_dataset]
-store = "$cache"                # or "$cache/derived" to key under <cache_root>/derived/<key>
+store = "$cache"                # or "$cache/derived" to key under <cache>/derived/datasets/<key>
 uri   = "https://example.com/big_file.nc"
 ```
 
@@ -114,19 +117,45 @@ defaults to `$data`. Define folders / overrides in `[_STORAGE]` (keys are bare
 ```toml
 [_STORAGE]
 default = "$data"                               # project-wide default selector
-scratch = "$TMPDIR/datasets"                    # user folder -> $scratch (a path expression)
-_HOST."login*" = { scratch = "/scratch/$USER/datasets" }   # host-glob override
-_PROFILE.hpc   = { data = "/work/datasets" }    # profile override (DATAMANIFEST_PROFILE=hpc)
+scratch = "$TMPDIR"                             # user folder -> $scratch (a bare root)
+_HOST."login*" = { scratch = "/scratch/$USER" }  # host-glob override
+_PREFIX = { datasets = "datasets", cached = "cached" }   # rename the per-layer subfolders
+_SCOPE  = { datasets = "shared-pool" }          # share fetched downloads within a group
 ```
 
 Every folder variable resolves through one ladder: `DATAMANIFEST_<NAME>_DIR`
-env-var → `_PROFILE.<name>` → first matching `_HOST.<glob>` → `[_STORAGE]` base →
-built-in default. Path expressions (`[_STORAGE]` values and `local_path`)
-interpolate `$`-folder variables, `$USER`/env, and `~`.
+env-var → first matching `_HOST.<glob>` → `[_STORAGE]` base → built-in default.
+(`_PROFILE` is shelved in spec-v3 — reserved/preserved, not resolved.) Prefixes and scopes
+resolve through `DATAMANIFEST_PREFIX_<KIND>` / `DATAMANIFEST_SCOPE_<KIND>` →
+`[_STORAGE._PREFIX | _SCOPE].<kind>` → default. Path expressions (`[_STORAGE]` values and
+`local_path`) interpolate `$`-folder variables, `$USER`/env, and `~`.
 
 When loading, DataManifest resolves the dataset's selected folder, then also
-probes the built-in folders `repo → data → cache`, returning the first where the
-dataset exists and has a `.complete` marker.
+probes the built-in folders `repo → data → cache` (each under its `datasets/` prefix),
+returning the first where the dataset exists and has a `.complete` marker. Existing v0.17.0
+downloads under `…/datamanifest/Datasets` are probed read-only for back-compat.
+
+## Produce-or-load caching (`@cached`)
+
+`DataManifest.Cache` adds the produce-or-load layer (spec-v3 `cache-produce`): cache a
+function's result on disk, keyed by its parameters rather than a `uri`.
+
+```julia
+@cached cachetype="anomaly" ext="jls" key=(a -> (; a.grid)) function load_anomaly(;
+        grid::String="5x5", _verbose::Bool=false)
+    # … expensive work …
+end
+load_anomaly(; grid="5x5")               # computes once; subsequent calls load from disk
+load_anomaly(; grid="5x5", cached=false) # escape hatch: run the body, no disk I/O
+```
+
+The key is the SHA-256 of the **canonical JSON** of the hash-affecting keyword parameters
+(`_`-prefixed kwargs are runtime knobs, excluded). Produced datasets are **keyword-only**,
+and hash inputs are restricted to strings/integers/booleans/arrays/objects — floats and
+nulls raise. Each artifact is self-describing: `config.toml` (re-hashable key table) and
+`metadata.toml` (provenance) sit alongside it at
+`<$cache>/cached/<project>/<cachetype>/[<version>/]<hash>/`, default `store = "$cache"`.
+`jls` is built in; register other formats with `DataManifest.Cache.register_format!`.
 
 ## Maintaining a local `Datasets.toml`
 

--- a/src/Cache.jl
+++ b/src/Cache.jl
@@ -1,0 +1,624 @@
+# Cache.jl — the produce-or-load (`@cached`) companion layer (spec-v3, capability
+# `cache-produce`).
+#
+# A *produced* dataset's bytes come from running a project function rather than
+# downloading a `uri`. It has NO entry in `datasets.toml`; its identity is
+# `(cachetype, param-hash)` where the hash is the SHA-256 of the canonical JSON (JCS,
+# RFC 8785) of its hash-affecting keyword parameters. On disk it lives at the composed
+# path (Storage §Produced-artifact location)
+#
+#   <folder>/cached/[<scope>/]<cachetype>/[<version>/]<hash>/
+#       ├── <basename>.<ext>   # the produced artifact
+#       ├── config.toml        # the re-hashable key table + [_META]{schema,cachetype,hash}
+#       ├── metadata.toml      # provenance (created/tool/host/user/[git]/[origin])
+#       └── .complete          # completion marker
+#
+# This layer reuses the core substrate: folder resolution + the `cached` content prefix
+# and project-scope (Storage), and the safe-materialization primitive (PipeLines). It
+# never touches the fetch path. Only the on-disk formats + the param hash are normative;
+# the `@cached` macro spelling is a per-language, non-normative ergonomic surface (its
+# shape is ported from LGMIO's `@cached`).
+#
+# Included into the DataManifest module after Storage / PipeLines.
+module Cache
+
+using TOML
+using SHA
+using Dates
+using Serialization
+using ..Storage: store_dir, is_complete, marker_path
+using ..PipeLines: materialize
+
+export @cached, param_hash, cache_key, cached_dir,
+    save_cache, load_cache, has_cache, read_config, config_is_valid, register_format!
+
+# ── Canonical JSON (JCS, RFC 8785) + parameter hash ──────────────────────────
+
+# Normalize a hash-input value to the spec-v3 restricted set (string / integer /
+# boolean / array / object of those). Symbols are coerced to strings (a clean,
+# deterministic projection). Floats, nulls, and anything else are a hard error —
+# spec-v3 disallows them in hash inputs (pass a float as a string).
+function _normalize_hashval(x)
+    if x isa Bool
+        return x
+    elseif x isa Integer
+        return Int(x)
+    elseif x isa AbstractString
+        return String(x)
+    elseif x isa Symbol
+        return String(x)
+    elseif x isa AbstractVector || x isa Tuple
+        return Any[_normalize_hashval(v) for v in x]
+    elseif x isa NamedTuple
+        return Dict{String,Any}(String(k) => _normalize_hashval(v) for (k, v) in pairs(x))
+    elseif x isa AbstractDict
+        return Dict{String,Any}(String(k) => _normalize_hashval(v) for (k, v) in x)
+    elseif x isa AbstractFloat
+        error("@cached: hash input contains a float ($x); spec-v3 disallows floats in " *
+              "hash inputs — pass it as a string (e.g. \"$(x)\"), which is also more " *
+              "hash-stable.")
+    elseif x === nothing || x === missing
+        error("@cached: hash input contains null/nothing; spec-v3 disallows nulls in hash " *
+              "inputs. Omit the parameter or pass a sentinel string instead.")
+    else
+        error("@cached: hash input contains an unsupported value of type $(typeof(x)); " *
+              "allowed: string, integer, boolean, and arrays/objects of those.")
+    end
+end
+
+# The normalized, hash-ready key table: every top-level key except `_`-prefixed runtime
+# knobs, recursively normalized to the restricted value set.
+function _key_table(kt)::Dict{String,Any}
+    d = _normalize_hashval(kt)
+    d isa AbstractDict || error("@cached: the key must be a table (NamedTuple/Dict), got $(typeof(kt))")
+    return Dict{String,Any}(k => v for (k, v) in d if !startswith(k, "_"))
+end
+
+# Minimal JSON string escaping per RFC 8785 (ECMAScript JSON.stringify): escape `"`,
+# `\`, and control chars < 0x20 (with \b \t \n \f \r short forms); emit everything else
+# (incl. non-ASCII) as raw UTF-8.
+function _jcs_string(io::IO, s::AbstractString)
+    print(io, '"')
+    for c in s
+        if c == '"'
+            print(io, "\\\"")
+        elseif c == '\\'
+            print(io, "\\\\")
+        elseif c == '\b'
+            print(io, "\\b")
+        elseif c == '\t'
+            print(io, "\\t")
+        elseif c == '\n'
+            print(io, "\\n")
+        elseif c == '\f'
+            print(io, "\\f")
+        elseif c == '\r'
+            print(io, "\\r")
+        elseif c < '\x20'
+            print(io, "\\u", lowercase(string(UInt16(c); base=16, pad=4)))
+        else
+            print(io, c)
+        end
+    end
+    print(io, '"')
+end
+
+# Serialize a normalized value to canonical JSON: object members sorted by Unicode code
+# point at every level, no insignificant whitespace, array order preserved.
+function _jcs(io::IO, x)
+    if x isa Bool
+        print(io, x ? "true" : "false")
+    elseif x isa Integer
+        print(io, string(x))
+    elseif x isa AbstractString
+        _jcs_string(io, x)
+    elseif x isa AbstractVector
+        print(io, '[')
+        for (i, v) in enumerate(x)
+            i > 1 && print(io, ',')
+            _jcs(io, v)
+        end
+        print(io, ']')
+    elseif x isa AbstractDict
+        ks = sort!(collect(keys(x)))   # code-point order
+        print(io, '{')
+        for (i, k) in enumerate(ks)
+            i > 1 && print(io, ',')
+            _jcs_string(io, k)
+            print(io, ':')
+            _jcs(io, x[k])
+        end
+        print(io, '}')
+    else
+        error("@cached: cannot canonicalize value of type $(typeof(x))")
+    end
+end
+
+"""
+    canonical_json(key_table) -> String
+
+The canonical-JSON (JCS / RFC 8785) projection of a key table — the exact bytes the
+parameter hash is taken over. Restricted to strings / integers / booleans / arrays /
+objects of those.
+"""
+function canonical_json(key_table)::String
+    io = IOBuffer()
+    _jcs(io, _key_table(key_table))
+    return String(take!(io))
+end
+
+"""
+    param_hash(key_table) -> String
+
+Lowercase 64-hex SHA-256 of the canonical JSON of `key_table` (its hash-affecting keyword
+parameters; `_`-prefixed keys are excluded). The cross-tool normative parameter hash.
+
+Reference vector: `param_hash(Dict("grid"=>"5x5","skip_models"=>["CESM.*","FGOALS.*"]))` ==
+`"83425a30d111562d46c1fce9de7618ea7f1f54e1be72e086cba0ac63c6f2ce9b"`.
+"""
+param_hash(key_table)::String = bytes2hex(sha256(canonical_json(key_table)))
+
+"""
+    cache_key(cachetype, hash; version=nothing) -> String
+
+The portable storage key: `"<cachetype>/<hash>"`, or `"<cachetype>/<version>/<hash>"` when
+a recipe `version` is set.
+"""
+function cache_key(cachetype::AbstractString, hash::AbstractString; version=nothing)::String
+    (version === nothing || isempty(version)) ? "$(cachetype)/$(hash)" :
+        "$(cachetype)/$(version)/$(hash)"
+end
+
+# ── Produced-artifact location ────────────────────────────────────────────────
+
+"""
+    cached_dir(cachetype, hash; version=nothing, store="\$cache", cache_dir=nothing,
+               storage_config=Dict(), env=ENV, host=gethostname(), project_root="",
+               declared_project="") -> String
+
+The directory holding a produced artifact and its sidecars. With an explicit `cache_dir`,
+it is used **verbatim** (`<cache_dir>/<cachetype>/[<version>/]<hash>`), bypassing folder /
+prefix / scope. Otherwise it composes via the `cached` content prefix and the cached scope
+(default: the project id): `<folder>/cached/[<scope>/]<cachetype>/[<version>/]<hash>`.
+"""
+function cached_dir(cachetype::AbstractString, hash::AbstractString;
+                    version=nothing, store::AbstractString="\$cache",
+                    cache_dir=nothing,
+                    storage_config::AbstractDict=Dict{String,Any}(),
+                    env=ENV, host::AbstractString=gethostname(),
+                    project_root::AbstractString="", declared_project::AbstractString="")::String
+    leaf = (version === nothing || isempty(version)) ?
+        joinpath(cachetype, hash) : joinpath(cachetype, version, hash)
+    if cache_dir !== nothing && !isempty(string(cache_dir))
+        return joinpath(String(cache_dir), leaf)
+    end
+    base = store_dir(store, :cached; storage_config=storage_config, env=env, host=host,
+                     project_root=project_root, declared_project=declared_project)
+    return joinpath(base, leaf)
+end
+
+# ── Sidecars (config.toml + metadata.toml) ────────────────────────────────────
+
+# TOML-safe coercion for values that are written but never hashed (metadata extras): keeps
+# floats/etc. (unlike the hash path), stringifies Symbols, drops nothing.
+_toml_safe(x::Bool) = x
+_toml_safe(x::Number) = x
+_toml_safe(x::AbstractString) = String(x)
+_toml_safe(x::Symbol) = String(x)
+_toml_safe(x::AbstractVector) = Any[_toml_safe(v) for v in x]
+_toml_safe(x::Tuple) = Any[_toml_safe(v) for v in x]
+_toml_safe(x::NamedTuple) = Dict{String,Any}(String(k) => _toml_safe(v) for (k, v) in pairs(x))
+_toml_safe(x::AbstractDict) = Dict{String,Any}(String(k) => _toml_safe(v) for (k, v) in x)
+_toml_safe(::Nothing) = ""
+_toml_safe(x) = string(x)
+
+"""
+    write_config(dir, key_table, cachetype; version=nothing, hash=nothing) -> String
+
+Write `<dir>/config.toml`: the key table at the root (written first) plus a `[_META]` block
+(`schema`, `cachetype`, optional `version`, `hash`). Returns the hash.
+"""
+function write_config(dir::AbstractString, key_table, cachetype::AbstractString;
+                      version=nothing, hash=nothing)::String
+    kt = _key_table(key_table)
+    h = hash === nothing ? bytes2hex(sha256(canonical_json(kt))) : String(hash)
+    meta = Dict{String,Any}("schema" => 1, "cachetype" => String(cachetype), "hash" => h)
+    (version !== nothing && !isempty(version)) && (meta["version"] = String(version))
+    out = Dict{String,Any}(kt)
+    out["_META"] = meta
+    open(joinpath(dir, "config.toml"), "w") do io
+        TOML.print(io, out; sorted=true)
+    end
+    return h
+end
+
+"""
+    read_config(dir) -> (; key_table, cachetype, version, hash)
+
+Read `<dir>/config.toml`: the key table is every root key except the `[_META]` block.
+"""
+function read_config(dir::AbstractString)
+    t = TOML.parsefile(joinpath(dir, "config.toml"))
+    meta = get(t, "_META", Dict{String,Any}())
+    kt = Dict{String,Any}(k => v for (k, v) in t if k != "_META")
+    return (key_table=kt, cachetype=get(meta, "cachetype", ""),
+            version=get(meta, "version", nothing), hash=get(meta, "hash", ""))
+end
+
+"""
+    config_is_valid(dir) -> Bool
+
+`true` iff `<dir>/config.toml` exists and the hash recomputed from its key table equals the
+recorded `_META.hash` (the re-hashability contract). A directory that fails this MUST NOT be
+treated as a valid cache hit.
+"""
+function config_is_valid(dir::AbstractString)::Bool
+    isfile(joinpath(dir, "config.toml")) || return false
+    c = read_config(dir)
+    return !isempty(c.hash) && param_hash(c.key_table) == c.hash
+end
+
+function _git_audit_block(project_root::AbstractString="")
+    git = Dict{String,Any}("commit" => "unknown", "branch" => "unknown", "dirty" => false)
+    repo = isempty(project_root) ? pwd() : String(project_root)
+    try
+        git["commit"] = strip(read(`git -C $repo rev-parse --short HEAD`, String))
+        git["branch"] = strip(read(`git -C $repo rev-parse --abbrev-ref HEAD`, String))
+        git["dirty"] = !isempty(strip(read(`git -C $repo status --porcelain`, String)))
+    catch e
+        e isa Union{Base.IOError,Base.ProcessFailedException,SystemError} || rethrow()
+    end
+    return git
+end
+
+_tool_string() = begin
+    v = try
+        pkgversion(@__MODULE__)
+    catch
+        nothing
+    end
+    v === nothing ? "DataManifest.jl" : "DataManifest.jl $(v)"
+end
+
+"""
+    write_metadata(dir; cachetype, extras=Dict(), cached_toml=nothing, project_root="") -> String
+
+Write `<dir>/metadata.toml` (provenance: `created`/`tool`/`host`/`user`/`[git]`, plus an
+optional `[origin].cached_toml`). **Write-if-absent** — a cache hit never re-stamps it.
+`extras` (audit-only, never hashed) are merged last and may override defaults.
+"""
+function write_metadata(dir::AbstractString; cachetype::AbstractString="",
+                        extras=Dict{String,Any}(), cached_toml=nothing,
+                        project_root::AbstractString="")::String
+    path = joinpath(dir, "metadata.toml")
+    isfile(path) && return path
+    audit = Dict{String,Any}(
+        "_META" => Dict{String,Any}("schema" => 1),
+        "created" => Dates.format(Dates.now(Dates.UTC), dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+        "tool" => _tool_string(),
+        "host" => gethostname(),
+        "user" => get(ENV, "USER", get(ENV, "USERNAME", "unknown")),
+        "git" => _git_audit_block(project_root),
+    )
+    (cached_toml !== nothing && !isempty(string(cached_toml))) &&
+        (audit["origin"] = Dict{String,Any}("cached_toml" => String(cached_toml)))
+    for (k, v) in _toml_safe(extras)
+        audit[k] = v
+    end
+    open(path, "w") do io
+        TOML.print(io, audit; sorted=true)
+    end
+    return path
+end
+
+# ── Artifact serialization (format registry; jls built-in) ────────────────────
+#
+# The produced-artifact byte format is per-tool / per-`format` and NOT assumed
+# cross-language-loadable (spec §What this spec does not specify). The core ships `jls`
+# (stdlib Serialization); heavy formats (nc, jld2, …) register a (save, load) pair from a
+# package extension, mirroring the read-side loader ladder.
+
+const _FORMATS = Dict{String,NamedTuple{(:save, :load),Tuple{Function,Function}}}()
+
+"""
+    register_format!(ext, save, load)
+
+Register a produced-artifact (de)serializer for extension `ext`: `save(data, path)` and
+`load(path)`. Lets an extension add `nc`/`jld2`/… without a hard dependency in the core.
+"""
+register_format!(ext::AbstractString, save::Function, load::Function) =
+    (_FORMATS[String(ext)] = (save=save, load=load); nothing)
+
+function _produce_save(data, path::AbstractString, ext::AbstractString)
+    if ext == "jls"
+        Serialization.serialize(path, data)
+    elseif haskey(_FORMATS, ext)
+        _FORMATS[ext].save(data, path)
+    else
+        error("@cached: no writer for format \"$(ext)\" (built-in: jls). Register one with " *
+              "DataManifest.Cache.register_format!(\"$(ext)\", save, load).")
+    end
+    return path
+end
+
+function _produce_load(path::AbstractString, ext::AbstractString)
+    if ext == "jls"
+        return Serialization.deserialize(path)
+    elseif haskey(_FORMATS, ext)
+        return _FORMATS[ext].load(path)
+    else
+        error("@cached: no reader for format \"$(ext)\" (built-in: jls). Register one with " *
+              "DataManifest.Cache.register_format!(\"$(ext)\", save, load).")
+    end
+end
+
+# ── Cache context (where produced artifacts default to) ───────────────────────
+#
+# Without a Database in scope, the produced path resolves from the environment (the
+# `$cache` folder) + the active project (for the cached scope = project id, and the git
+# audit anchor). An explicit `cache_dir` per call overrides location entirely.
+
+function _cache_context()
+    proot = try
+        dirname(Base.active_project())
+    catch
+        pwd()
+    end
+    return (storage_config=Dict{String,Any}(), project_root=proot, declared_project="")
+end
+
+# ── save / load / has (functional API used by the macro and directly) ─────────
+
+"""
+    save_cache(data, cachetype, key_table; ext="jls", basename="data", version=nothing,
+               store="\$cache", cache_dir=nothing, extras=Dict()) -> String
+
+Materialize `data` as a produced artifact at the composed cache directory and write the
+`config.toml` / `metadata.toml` sidecars. Returns the artifact directory.
+"""
+function save_cache(data, cachetype::AbstractString, key_table;
+                    ext::AbstractString="jls", basename::AbstractString="data",
+                    version=nothing, store::AbstractString="\$cache", cache_dir=nothing,
+                    extras=Dict{String,Any}())::String
+    ctx = _cache_context()
+    h = param_hash(key_table)
+    dir = cached_dir(cachetype, h; version=version, store=store, cache_dir=cache_dir,
+                     storage_config=ctx.storage_config, project_root=ctx.project_root,
+                     declared_project=ctx.declared_project)
+    materialize(dir) do tmp
+        mkpath(tmp)
+        _produce_save(data, joinpath(tmp, "$(basename).$(ext)"), ext)
+        write_config(tmp, key_table, cachetype; version=version, hash=h)
+        write_metadata(tmp; cachetype=cachetype, extras=extras, project_root=ctx.project_root)
+    end
+    return dir
+end
+
+"""
+    has_cache(cachetype, key_table; version=nothing, store="\$cache", cache_dir=nothing) -> Bool
+
+`true` iff a complete, hash-valid produced artifact exists for these parameters.
+"""
+function has_cache(cachetype::AbstractString, key_table;
+                   version=nothing, store::AbstractString="\$cache", cache_dir=nothing)::Bool
+    ctx = _cache_context()
+    h = param_hash(key_table)
+    dir = cached_dir(cachetype, h; version=version, store=store, cache_dir=cache_dir,
+                     storage_config=ctx.storage_config, project_root=ctx.project_root,
+                     declared_project=ctx.declared_project)
+    return is_complete(dir) && config_is_valid(dir)
+end
+
+"""
+    load_cache(cachetype, key_table; ext="jls", basename="data", version=nothing,
+               store="\$cache", cache_dir=nothing) -> data or nothing
+
+Return the produced artifact for these parameters, or `nothing` on a miss.
+"""
+function load_cache(cachetype::AbstractString, key_table;
+                    ext::AbstractString="jls", basename::AbstractString="data",
+                    version=nothing, store::AbstractString="\$cache", cache_dir=nothing)
+    ctx = _cache_context()
+    h = param_hash(key_table)
+    dir = cached_dir(cachetype, h; version=version, store=store, cache_dir=cache_dir,
+                     storage_config=ctx.storage_config, project_root=ctx.project_root,
+                     declared_project=ctx.declared_project)
+    (is_complete(dir) && config_is_valid(dir)) || return nothing
+    return _produce_load(joinpath(dir, "$(basename).$(ext)"), ext)
+end
+
+# The produce-or-load core invoked by the `@cached` wrapper: fast-path load on a hit,
+# otherwise compute + save under the safe-materialization primitive.
+function _run_cached(body::Function, cachetype::AbstractString, key_table;
+                     ext::AbstractString="jls", basename::AbstractString="data",
+                     version=nothing, store::AbstractString="\$cache", cache_dir=nothing,
+                     extras=Dict{String,Any}())
+    ctx = _cache_context()
+    h = param_hash(key_table)
+    dir = cached_dir(cachetype, h; version=version, store=store, cache_dir=cache_dir,
+                     storage_config=ctx.storage_config, project_root=ctx.project_root,
+                     declared_project=ctx.declared_project)
+    artifact = joinpath(dir, "$(basename).$(ext)")
+    if is_complete(dir) && config_is_valid(dir)
+        return _produce_load(artifact, ext)
+    end
+    local result
+    materialize(dir) do tmp
+        mkpath(tmp)
+        result = body()
+        _produce_save(result, joinpath(tmp, "$(basename).$(ext)"), ext)
+        write_config(tmp, key_table, cachetype; version=version, hash=h)
+        write_metadata(tmp; cachetype=cachetype, extras=extras, project_root=ctx.project_root)
+    end
+    return result
+end
+
+# ── @cached macro (non-normative ergonomic surface; ported from LGMIO) ─────────
+
+# Extract the argument name from a signature expression (sym, sym::T, sym=default,
+# sym::T=default).
+function _cached_argname(ex)
+    if isa(ex, Symbol)
+        return ex
+    elseif Meta.isexpr(ex, :kw)
+        return _cached_argname(ex.args[1])
+    elseif Meta.isexpr(ex, :(::))
+        return _cached_argname(ex.args[1])
+    elseif Meta.isexpr(ex, :...)
+        error("@cached does not support splat arguments: $(ex)")
+    else
+        error("@cached: cannot extract name from argument expression: $(ex)")
+    end
+end
+
+"""
+    @cached cachetype="name" key=(args -> (;…)) [ext="jls"] [basename="data"]
+            [version="v3"] [store="\$cache"] function fn(; kw…) … end
+
+Wrap a **keyword-only** function with transparent produce-or-load disk caching (spec-v3
+`cache-produce`).
+
+- `cachetype` (String literal, required): the artifact namespace.
+- `key` (required): a callable receiving a NamedTuple of the function's hash-affecting
+  keyword arguments (every declared kwarg except `_`-prefixed runtime knobs) and returning
+  the **key table** (a NamedTuple/Dict). Its canonical-JSON SHA-256 is the parameter hash.
+  Hash inputs are restricted to strings/integers/booleans/arrays/objects of those — floats
+  and nulls raise (pass a float as a string).
+- `ext` (default `"jls"`): artifact serialization format. `jls` (stdlib `Serialization`) is
+  built in; register others with `DataManifest.Cache.register_format!`.
+- `basename` (default `"data"`), `version` (optional recipe/code version → a path segment,
+  not in the hash), `store` (default `"\$cache"`).
+
+The wrapper injects a `cached::Bool=true` escape hatch (`cached=false` runs the body with no
+disk I/O). A kwarg named exactly `_metadata_extras` (NamedTuple/Dict/`nothing`) is an
+audit-only channel merged into `metadata.toml` without affecting the hash; any other
+`_`-prefixed kwarg is a runtime knob excluded from the hash but visible in the body.
+
+**Produced datasets are keyword-only** — a function with positional arguments is rejected
+(a positional list has no stable name→value identity to hash).
+"""
+macro cached(args...)
+    length(args) >= 2 || error("@cached expects at least `cachetype=...`, `key=...`, and a function definition")
+    fdef = args[end]
+    kw_args = args[1:end-1]
+
+    cachetype = nothing
+    keyfn = nothing
+    ext = nothing
+    basename = nothing
+    version = nothing
+    store = nothing
+    for kw in kw_args
+        Meta.isexpr(kw, :(=)) || error("@cached: expected `name=value`, got $(kw)")
+        name, val = kw.args
+        if name === :cachetype
+            isa(val, String) || error("@cached: `cachetype` must be a String literal")
+            cachetype = val
+        elseif name === :key
+            keyfn = val
+        elseif name === :ext
+            isa(val, String) || error("@cached: `ext` must be a String literal")
+            ext = val
+        elseif name === :basename
+            isa(val, String) || error("@cached: `basename` must be a String literal")
+            basename = val
+        elseif name === :version
+            isa(val, String) || error("@cached: `version` must be a String literal")
+            version = val
+        elseif name === :store
+            isa(val, String) || error("@cached: `store` must be a String literal")
+            store = val
+        else
+            error("@cached: unknown argument `$name`. Expected `cachetype`, `key`, `ext`, `basename`, `version`, or `store`.")
+        end
+    end
+    cachetype === nothing && error("@cached: missing required `cachetype=...`")
+    keyfn === nothing && error("@cached: missing required `key=...`")
+
+    if Meta.isexpr(fdef, :block)
+        fdefs = filter(x -> !(x isa LineNumberNode), fdef.args)
+        length(fdefs) == 1 || error("@cached: expected exactly one function definition")
+        fdef = fdefs[1]
+    end
+    Meta.isexpr(fdef, :function) || (Meta.isexpr(fdef, :(=)) && Meta.isexpr(fdef.args[1], :call)) ||
+        error("@cached: expected a function definition, got $(fdef)")
+
+    sig = fdef.args[1]
+    body = fdef.args[2]
+    Meta.isexpr(sig, :call) || error("@cached: unexpected signature form: $(sig)")
+    fname = sig.args[1]
+    rest = sig.args[2:end]
+
+    pos_args = Any[]
+    kw_params = Any[]
+    for a in rest
+        if Meta.isexpr(a, :parameters)
+            append!(kw_params, a.args)
+        else
+            push!(pos_args, a)
+        end
+    end
+
+    # spec-v3: produced datasets are keyword-only.
+    if !isempty(pos_args)
+        names = join(string.(_cached_argname.(pos_args)), ", ")
+        error("@cached: produced datasets are keyword-only (spec-v3); `$(fname)` has " *
+              "positional argument(s): $names. Make them keyword arguments.")
+    end
+
+    kw_names = Symbol[_cached_argname(a) for a in kw_params]
+    :cached in kw_names && error("@cached: the wrapped function already has a `cached` argument")
+
+    # Key NamedTuple: every declared kwarg except `_`-prefixed runtime knobs.
+    key_names = Symbol[n for n in kw_names if !startswith(string(n), "_")]
+    nt_args = Expr(:tuple, Expr(:parameters, [Expr(:kw, n, n) for n in key_names]...))
+
+    has_meta_extras = :_metadata_extras in kw_names
+    has_cache_dir = :cache_dir in kw_names
+
+    new_kw_params = copy(kw_params)
+    push!(new_kw_params, Expr(:kw, :(cached::Bool), true))
+    new_sig = Expr(:call, fname, Expr(:parameters, new_kw_params...))
+
+    build_extras = if has_meta_extras
+        quote
+            let _e = _metadata_extras
+                if _e === nothing
+                    Dict{String,Any}()
+                elseif _e isa NamedTuple
+                    Dict{String,Any}(string(k) => v for (k, v) in pairs(_e))
+                elseif _e isa AbstractDict
+                    Dict{String,Any}(string(k) => v for (k, v) in pairs(_e))
+                else
+                    error("@cached: `_metadata_extras` must be a NamedTuple, AbstractDict, or nothing; got $(typeof(_e))")
+                end
+            end
+        end
+    else
+        :(Dict{String,Any}())
+    end
+
+    cd_expr = has_cache_dir ? :(cache_dir) : :(nothing)
+    _ext = ext === nothing ? "jls" : ext
+    _basename = basename === nothing ? "data" : basename
+    _version = version === nothing ? nothing : version
+    _store = store === nothing ? "\$cache" : store
+    _run = GlobalRef(@__MODULE__, :_run_cached)
+
+    body_fn = Expr(:(->), Expr(:tuple), body)
+
+    wrapper = quote
+        _body_fn = $body_fn
+        if !cached
+            return _body_fn()
+        end
+        _kt = $(keyfn)($nt_args)
+        return $_run(_body_fn, $cachetype, _kt;
+            ext=$_ext, basename=$_basename, version=$_version, store=$_store,
+            cache_dir=$cd_expr, extras=$build_extras)
+    end
+
+    return esc(Expr(:function, new_sig, wrapper))
+end
+
+end # module Cache

--- a/src/DataManifest.jl
+++ b/src/DataManifest.jl
@@ -17,6 +17,7 @@ include("Storage.jl")
 include("Databases.jl")
 include("DefaultLoaders.jl")
 include("PipeLines.jl")
+include("Cache.jl")
 
 # Extend Base.write for Database (Databases.write is the implementation)
 write(db::Databases.Database, path::String; kwargs...) = Databases.write(db, path; kwargs...)
@@ -40,7 +41,10 @@ using .PipeLines: download_dataset, download_datasets, load_dataset, get_project
 
 const add_dataset = add
 
-export Databases, PipeLines, Loaders, Storage
+export Databases, PipeLines, Loaders, Storage, Cache
+# Produce-or-load (`@cached`) companion layer — spec-v3 `cache-produce`.
+using .Cache: @cached, param_hash, cache_key
+export @cached, param_hash, cache_key
 export Database, DatasetEntry
 export set_datasets_folder, set_datasets, get_datasets_folder, get_datasets
 export repr_short, string_short

--- a/src/Databases.jl
+++ b/src/Databases.jl
@@ -5,8 +5,8 @@ using TOML
 using URIs
 using ..Config: info, warn, sha256_path, get_extract_path, get_default_toml, DEFAULT_DATASETS_FOLDER_PATH,
     COMPRESSED_FORMATS, HIDE_STRUCT_FIELDS, project_root_from_paths
-using ..Storage: selector_root, folder_root, expand_path_expr, legacy_data_root,
-    is_complete, BUILTIN_FOLDERS
+using ..Storage: store_dir, selector_root, expand_path_expr, legacy_data_root,
+    legacy_v2_roots, is_complete, BUILTIN_FOLDERS
 
 # ----- Types (DatasetEntry, Database) -----
 Base.@kwdef mutable struct DatasetEntry
@@ -464,17 +464,18 @@ function get_dataset_key(entry::DatasetEntry)
     return build_dataset_key(entry)
 end
 
-# Resolve the root directory for an entry's store **selector** (spec-v2). A blank
-# `store` falls back to the project-wide `default` selector (itself defaulting to
-# `$data`). An explicitly-provided `datasets_folder` (non-empty) overrides the
-# `$data` root for back-compat; every other selector resolves via the `Storage`
-# module ($-folder ladder + sub-paths).
+# Resolve the directory under which an entry's `<key>` lives (spec-v3). A blank `store`
+# falls back to the project-wide `default` selector (itself defaulting to `$data`). The
+# fetched path composes selector + the `datasets/` content prefix + (optional) datasets
+# scope: `<root>[/subpath]/datasets/[<scope>/]<key>`. An explicitly-provided
+# `datasets_folder` (non-empty) is used verbatim for the `$data` selector (back-compat —
+# an exact folder, no prefix/scope).
 function resolve_store_root(entry::DatasetEntry, datasets_folder::String=""; project_root::String="", storage_config::AbstractDict=Dict{String,Any}())
     selector = entry.store == "" ? _default_selector(storage_config) : entry.store
     if datasets_folder != "" && selector == "\$data"
         return datasets_folder
     end
-    return selector_root(selector; project_root=project_root, storage_config=storage_config)
+    return store_dir(selector, :datasets; project_root=project_root, storage_config=storage_config)
 end
 
 function get_dataset_path(entry::DatasetEntry, datasets_folder::String=""; extract::Union{Bool,Nothing}=nothing, project_root::String="", storage_config::AbstractDict=Dict{String,Any}())
@@ -535,14 +536,19 @@ function resolve_existing_path(db::Database, entry::DatasetEntry; extract::Union
             return candidate
         end
     end
-    # Legacy read-only back-compat probe (pre-v1.1 default ~/.cache/Datasets),
-    # checked last so any new-store copy wins. Skipped when the user has made an
-    # explicit data-dir choice (DATAMANIFEST_DATA_DIR). New writes never go here.
-    if get(ENV, "DATAMANIFEST_DATA_DIR", "") == ""
-        legacy_candidate = joinpath(legacy_data_root(), key)
-        if ispath(legacy_candidate)
-            _warn_legacy_dir_once()
-            return legacy_candidate
+    # Legacy read-only back-compat probes, checked last so any new-store copy wins.
+    # Skipped when the user has made an explicit data-dir choice (DATAMANIFEST_DATA_DIR /
+    # DATAMANIFEST_DIR). New writes never go to these paths.
+    #   · the spec-v2 / v0.17.0 roots `<app-dir>/Datasets/<key>` (capital D; spec-v3
+    #     lowercased the prefix and moved to bare roots);
+    #   · the pre-v1.1 default `$XDG_CACHE_HOME/Datasets/<key>`.
+    if get(ENV, "DATAMANIFEST_DATA_DIR", "") == "" && get(ENV, "DATAMANIFEST_DIR", "") == ""
+        for root in vcat(legacy_v2_roots(), legacy_data_root())
+            legacy_candidate = joinpath(root, key)
+            if ispath(legacy_candidate)
+                _warn_legacy_dir_once()
+                return legacy_candidate
+            end
         end
     end
     return get_dataset_path(db, entry; extract=extract)
@@ -580,7 +586,7 @@ function _warn_legacy_dir_once()
     _LEGACY_DIR_WARNED[] && return
     _LEGACY_DIR_WARNED[] = true
     legacy = legacy_data_root()
-    current = selector_root("\$data")
+    current = store_dir("\$data", :datasets)
     warn("Reading datasets from the legacy location $legacy (pre-v1.1 default; read-only). " *
          "New downloads go to the current data store at $current. To keep using the legacy " *
          "folder, set DATAMANIFEST_DATA_DIR=$legacy; otherwise migrate it manually " *

--- a/src/Storage.jl
+++ b/src/Storage.jl
@@ -1,46 +1,58 @@
 """
     Storage
 
-Pure resolver for the spec-v2 `\$`-folder-variable storage model.
+Pure resolver for the spec-v3 storage model: **bare folder roots** + **layer-applied
+content prefixes** (`datasets/` for fetch, `cached/` for produce) + an optional **scope**
+partition segment.
 
-A **folder** is a named location referenced as a `\$`-variable. There is one
-namespace with three built-in members and any number of user-defined ones:
+A **folder** is a named top-level *location* referenced as a `\$`-variable. One namespace,
+three built-in members plus any number of user-defined ones:
 
-- `\$data`  → `platformdirs.user_data_dir("datamanifest")` + `/Datasets`
-- `\$cache` → `platformdirs.user_cache_dir("datamanifest")` + `/Datasets`
-- `\$repo`  → `<project_root>/datasets`
-- user-defined: any other key under `[_STORAGE]` (e.g. `scratch = "…"` → `\$scratch`)
+- `\$data`  → `\$DATAMANIFEST_DIR` if set, else `platformdirs.user_data_dir("datamanifest")`
+- `\$cache` → `\$DATAMANIFEST_DIR` if set, else `platformdirs.user_cache_dir("datamanifest")`
+- `\$repo`  → `<project_root>`
+- user-defined: any other bare key under `[_STORAGE]` (`scratch = "…"` → `\$scratch`)
 
-Default root locations are **language-independent** — they match Python's
-`platformdirs` so a peer tool resolves the same dataset to the same on-disk path
-(NOT the Julia depot). The core knows *locations only* — no lifetime policy.
+A folder resolves to a **bare root** (no trailing `Datasets`/`datasets`). The consuming
+layer composes the rest of the path:
+
+    fetched:  <root>[/subpath]/<datasets-prefix>/[<datasets-scope>/]<key>
+    produced: <root>[/subpath]/<cached-prefix>/[<cached-scope>/]<cachetype>/[<version>/]<hash>
+
+So the same folder holds fetched data and produced artifacts as sibling subtrees. Default
+roots are language-independent (Python's `platformdirs` is the normative reference); the
+core knows *locations only* — no lifetime policy.
 
 Two kinds of value:
 
-- **Selectors** (`store`, `[_STORAGE].default`) — a `\$`-folder reference,
-  optionally with a literal sub-path: `\$cache/derived`. Resolved by
-  [`selector_root`]; the dataset lands at `<root>[/subpath]/<key>`.
-- **Path expressions** (`[_STORAGE]` values, `local_path`) — full paths that may
-  interpolate `\$`-folder variables, `\$USER`/env vars, and `~`. Resolved by
-  [`expand_path_expr`].
+- **Selectors** (`store`, `[_STORAGE].default`) — a `\$`-folder reference, optionally with a
+  sub-path (`\$cache/sub`). Resolved by [`selector_root`] to `<root>[/subpath]`; the layer
+  then appends prefix/scope/key (see [`store_dir`]).
+- **Path expressions** (`[_STORAGE]` values, `local_path`) — full paths interpolating
+  `\$`-folder variables, `\$USER`/env, and `~`. Resolved by [`expand_path_expr`].
 
-Every folder variable — built-in and user-defined alike — resolves through one
-ladder (see [`folder_root`]). The module is intentionally pure: given explicit
-`env` / `host` / `profile` arguments it is deterministic and testable without
-touching the real environment.
+Every folder variable resolves through one ladder (see [`folder_root`]):
+`DATAMANIFEST_<NAME>_DIR` env → `[_STORAGE._HOST.<glob>].<name>` → `[_STORAGE].<name>` →
+built-in default. (`_PROFILE` is shelved in spec-v3 — reserved/preserved, not resolved.)
 
-Linux is the primary verified target; macOS / Windows defaults follow the same
-`platformdirs` conventions (documented inline, less heavily exercised).
+The module is intentionally pure: given explicit `env` / `host` arguments it is
+deterministic and testable without touching the real environment. Linux is the primary
+verified target; macOS / Windows defaults follow the same `platformdirs` conventions.
 """
 module Storage
 
-export folder_root, selector_root, expand_path_expr, legacy_data_root, BUILTIN_FOLDERS
+using TOML
+using SHA
+
+export folder_root, selector_root, store_dir, expand_path_expr,
+    content_prefix, content_scope, project_id,
+    legacy_data_root, legacy_v2_roots, BUILTIN_FOLDERS
 
 """Built-in folder variables (the only ones with a built-in default location)."""
 const BUILTIN_FOLDERS = ("data", "cache", "repo")
 
-"""Reserved `[_STORAGE]` keys that are NOT folder variables."""
-const RESERVED_STORAGE_KEYS = ("default", "_HOST", "_PROFILE")
+"""Reserved `[_STORAGE]` keys that are NOT folder variables (spec-v3)."""
+const RESERVED_STORAGE_KEYS = ("default", "_HOST", "_PREFIX", "_SCOPE", "_PROFILE")
 
 # --- glob matching (`*`, `?`) for `_HOST` patterns ---------------------------
 
@@ -70,15 +82,15 @@ function _glob_match(pattern::AbstractString, s::AbstractString)::Bool
     return occursin(Regex(String(take!(buf))), s)
 end
 
-# --- platformdirs-equivalent default roots -----------------------------------
+# --- platformdirs-equivalent default roots (bare app dirs, spec-v3) ----------
 
 """
     _user_data_dir(env) -> String
 
-`platformdirs.user_data_dir("datamanifest")`. Linux:
-`\$XDG_DATA_HOME` (default `~/.local/share`) + `/datamanifest`. macOS:
+`platformdirs.user_data_dir("datamanifest")` — the **bare** app data dir (no trailing
+`datasets`). Linux: `\$XDG_DATA_HOME` (default `~/.local/share`) + `/datamanifest`. macOS:
 `~/Library/Application Support/datamanifest`. Windows: `%LOCALAPPDATA%` +
-`/datamanifest/datamanifest` (platformdirs doubles the missing appauthor).
+`/datamanifest/datamanifest`.
 """
 function _user_data_dir(env)::String
     if Sys.iswindows()
@@ -95,9 +107,9 @@ end
 """
     _user_cache_dir(env) -> String
 
-`platformdirs.user_cache_dir("datamanifest")`. Linux: `\$XDG_CACHE_HOME`
-(default `~/.cache`) + `/datamanifest`. macOS: `~/Library/Caches/datamanifest`.
-Windows: `%LOCALAPPDATA%` + `/datamanifest/datamanifest/Cache`.
+`platformdirs.user_cache_dir("datamanifest")` — the **bare** app cache dir. Linux:
+`\$XDG_CACHE_HOME` (default `~/.cache`) + `/datamanifest`. macOS:
+`~/Library/Caches/datamanifest`. Windows: `%LOCALAPPDATA%` + `/datamanifest/datamanifest/Cache`.
 """
 function _user_cache_dir(env)::String
     if Sys.iswindows()
@@ -114,16 +126,17 @@ end
 """
     _builtin_default(name, project_root, env) -> Union{String,Nothing}
 
-The language-independent built-in default root for a built-in folder, or
-`nothing` for a user-defined folder (which has no built-in default).
+The language-independent built-in **bare root** for a built-in folder, or `nothing` for a
+user-defined folder. `DATAMANIFEST_DIR`, when set, is the application base for `\$data` and
+`\$cache`; `\$repo` is always project-relative.
 """
 function _builtin_default(name::AbstractString, project_root::AbstractString, env)
     if name == "repo"
-        return joinpath(String(project_root), "datasets")
-    elseif name == "cache"
-        return joinpath(_user_cache_dir(env), "Datasets")
-    elseif name == "data"
-        return joinpath(_user_data_dir(env), "Datasets")
+        return String(project_root)
+    elseif name == "data" || name == "cache"
+        dir = get(env, "DATAMANIFEST_DIR", "")
+        !isempty(dir) && return String(dir)
+        return name == "cache" ? _user_cache_dir(env) : _user_data_dir(env)
     else
         return nothing
     end
@@ -133,23 +146,33 @@ end
     legacy_data_root(env=ENV) -> String
 
 The pre-v1.1 default datasets folder — `\$XDG_CACHE_HOME/Datasets` (default
-`~/.cache/Datasets`). A **read-only** back-compat probe location: spec-v1.1 moved
-the default `data` folder under a `datamanifest/` namespace (see `_user_data_dir`),
-orphaning datasets downloaded by older versions here. Read resolution probes it
-last so old downloads still resolve; new writes never land here. Must match the
-Python tool's `storage.legacy_data_root()`.
+`~/.cache/Datasets`). A **read-only** back-compat probe location, checked last so old
+downloads still resolve; new writes never land here.
 """
 function legacy_data_root(env=ENV)::String
     base = get(env, "XDG_CACHE_HOME", joinpath(homedir(), ".cache"))
     return joinpath(base, "Datasets")
 end
 
+"""
+    legacy_v2_roots(env=ENV) -> Vector{String}
+
+The spec-v2 (v0.17.0) dataset roots — the bare app dirs plus a capital-`Datasets` segment
+(`<user_data_dir>/Datasets`, `<user_cache_dir>/Datasets`). spec-v3 lowercased the prefix to
+`datasets/` and moved folders to bare roots, orphaning anything v0.17.0 wrote. These are
+**read-only** transitional probe roots (a dataset's `<root>/<key>` is checked under each);
+new writes never land here.
+"""
+function legacy_v2_roots(env=ENV)::Vector{String}
+    return [joinpath(_user_data_dir(env), "Datasets"),
+            joinpath(_user_cache_dir(env), "Datasets")]
+end
+
 # --- folder-variable name discovery ------------------------------------------
 
-# The set of names that are folder *variables* (so `$NAME` in a path expression
-# expands to a folder root rather than an env var): built-ins plus every name
-# defined anywhere in `[_STORAGE]` (base keys and `_HOST` / `_PROFILE` overrides),
-# excluding the reserved keys.
+# Names that are folder *variables* (so `$NAME` in a path expression expands to a folder
+# root rather than an env var): built-ins plus every base/_HOST-defined name, excluding the
+# reserved keys. `_PREFIX` / `_SCOPE` inner keys (`datasets`/`cached`) are NOT folder vars.
 function _folder_var_names(storage_config::AbstractDict)::Set{String}
     names = Set{String}(BUILTIN_FOLDERS)
     for (k, _) in storage_config
@@ -157,14 +180,12 @@ function _folder_var_names(storage_config::AbstractDict)::Set{String}
         ks in RESERVED_STORAGE_KEYS && continue
         push!(names, ks)
     end
-    for sub in ("_HOST", "_PROFILE")
-        t = get(storage_config, sub, nothing)
-        if t isa AbstractDict
-            for (_, entry) in t
-                if entry isa AbstractDict
-                    for (kk, _) in entry
-                        push!(names, String(kk))
-                    end
+    hosts = get(storage_config, "_HOST", nothing)
+    if hosts isa AbstractDict
+        for (_, entry) in hosts
+            if entry isa AbstractDict
+                for (kk, _) in entry
+                    push!(names, String(kk))
                 end
             end
         end
@@ -176,19 +197,17 @@ end
 
 """
     expand_path_expr(expr; project_root="", storage_config=Dict(), env=ENV,
-                     host=gethostname(), profile=…) -> String
+                     host=gethostname()) -> String
 
-Expand a **path expression**: `\$NAME` / `\${NAME}` and a leading `~`. `\$NAME`
-expands to the folder variable `NAME` (resolved through [`folder_root`]) if one is
-defined, otherwise to the environment variable `NAME`; an undefined name is left
-verbatim. `~` expands to the home directory.
+Expand a **path expression**: `\$NAME` / `\${NAME}` and a leading `~`. `\$NAME` expands to
+the folder variable `NAME` (via [`folder_root`]) if defined, otherwise the environment
+variable `NAME`; an undefined name is left verbatim. `~` expands to the home directory.
 """
 function expand_path_expr(expr::AbstractString;
                           project_root::AbstractString="",
                           storage_config::AbstractDict=Dict{String,Any}(),
                           env=ENV,
                           host::AbstractString=gethostname(),
-                          profile::AbstractString=get(ENV, "DATAMANIFEST_PROFILE", ""),
                           _seen::Set{String}=Set{String}())::String
     s = String(expr)
     fvars = _folder_var_names(storage_config)
@@ -197,7 +216,7 @@ function expand_path_expr(expr::AbstractString;
         nm = String(name)
         if nm in fvars
             return folder_root(nm; project_root=project_root, storage_config=storage_config,
-                               env=env, host=host, profile=profile, _seen=_seen)
+                               env=env, host=host, _seen=_seen)
         elseif haskey(env, nm)
             return String(env[nm])
         else
@@ -210,32 +229,31 @@ function expand_path_expr(expr::AbstractString;
     return expanduser(s)
 end
 
-# --- folder resolution (the unified ladder) ----------------------------------
+# --- folder resolution (the unified ladder, spec-v3) -------------------------
 
 """
     folder_root(name; project_root="", storage_config=Dict(), env=ENV,
-                host=gethostname(), profile=…) -> String
+                host=gethostname()) -> String
 
-Resolve a single folder variable `name` (built-in or user-defined) to a root
-directory. One ladder for every variable; the first rung that applies wins:
+Resolve a single folder variable `name` (built-in or user-defined) to a **bare root**. One
+ladder for every variable; the first rung that applies wins:
 
 1. the `DATAMANIFEST_<NAME>_DIR` environment variable;
-2. the `[_STORAGE._PROFILE.<profile>].<name>` entry, when `profile != ""`;
-3. the first matching `[_STORAGE._HOST.<glob>].<name>` entry (glob `*`/`?` vs `host`);
-4. the base `[_STORAGE].<name>` definition;
-5. the built-in default (`data` / `cache` / `repo` only).
+2. the first matching `[_STORAGE._HOST.<glob>].<name>` entry (glob `*`/`?` vs `host`);
+3. the base `[_STORAGE].<name>` definition;
+4. the built-in default (`\$data`/`\$cache` → `\$DATAMANIFEST_DIR` or platformdirs;
+   `\$repo` → `<project_root>`).
 
-A user-defined name unresolved on every rung is an error. The value at rungs 1–4
-is a **path expression** (it may interpolate other folder variables, `\$USER`/env,
-`~`); a relative `repo` value is resolved against `project_root`. A folder variable
-that references itself (directly or transitively) is an error.
+(spec-v3 dropped the `_PROFILE` rung — `_PROFILE` is reserved/preserved, not resolved.) A
+user-defined name unresolved on every rung is an error. The value at rungs 1–3 is a **path
+expression**; a relative `repo` value is resolved against `project_root`. A folder variable
+that references itself is an error.
 """
 function folder_root(name::AbstractString;
                      project_root::AbstractString="",
                      storage_config::AbstractDict=Dict{String,Any}(),
                      env=ENV,
                      host::AbstractString=gethostname(),
-                     profile::AbstractString=get(ENV, "DATAMANIFEST_PROFILE", ""),
                      _seen::Set{String}=Set{String}())::String
     name = String(name)
     if name in _seen
@@ -245,8 +263,9 @@ function folder_root(name::AbstractString;
 
     expand(raw) = expand_path_expr(string(raw); project_root=project_root,
                                    storage_config=storage_config, env=env, host=host,
-                                   profile=profile, _seen=seen2)
-    finalize(p) = (name == "repo" && !isabspath(p)) ? joinpath(String(project_root), p) : p
+                                   _seen=seen2)
+    finalize(p) = (name == "repo" && !isabspath(p) && !isempty(project_root)) ?
+        joinpath(String(project_root), p) : p
 
     # (1) DATAMANIFEST_<NAME>_DIR
     envkey = "DATAMANIFEST_$(uppercase(name))_DIR"
@@ -254,18 +273,7 @@ function folder_root(name::AbstractString;
         return finalize(expand(env[envkey]))
     end
 
-    # (2) _PROFILE.<profile>.<name>
-    if !isempty(profile)
-        prof = get(storage_config, "_PROFILE", nothing)
-        if prof isa AbstractDict && haskey(prof, profile)
-            entry = prof[profile]
-            if entry isa AbstractDict && haskey(entry, name)
-                return finalize(expand(entry[name]))
-            end
-        end
-    end
-
-    # (3) first matching _HOST.<glob>.<name>
+    # (2) first matching _HOST.<glob>.<name>
     hosts = get(storage_config, "_HOST", nothing)
     if hosts isa AbstractDict
         for pat in sort(collect(keys(hosts)))  # deterministic iteration
@@ -276,13 +284,13 @@ function folder_root(name::AbstractString;
         end
     end
 
-    # (4) base [_STORAGE].<name>
+    # (3) base [_STORAGE].<name>
     if !(name in RESERVED_STORAGE_KEYS) && haskey(storage_config, name) &&
        !isempty(string(storage_config[name]))
         return finalize(expand(storage_config[name]))
     end
 
-    # (5) built-in default (data/cache/repo only)
+    # (4) built-in default
     d = _builtin_default(name, project_root, env)
     d !== nothing && return d
     error("Unknown storage folder variable \$$name: not built-in (data/cache/repo) " *
@@ -293,13 +301,12 @@ end
 
 """
     selector_root(selector; project_root="", storage_config=Dict(), env=ENV,
-                  host=gethostname(), profile=…) -> String
+                  host=gethostname()) -> String
 
-Resolve a `store` / `default` **selector** to a root directory. A selector is a
-`\$`-folder reference optionally followed by a literal sub-path:
-`\$<folder>[/<subpath>]` → `<resolved-folder>[/<subpath>]`. The dataset's bytes
-land at `<root>/<key>`. A non-`\$` (bare) selector is rejected — spec-v2 selectors
-MUST be `\$`-references (bare names are migrated by the caller before this point).
+Resolve a `store` / `default` **selector** to `<root>[/subpath]`. A selector is a
+`\$`-folder reference optionally followed by a literal sub-path (`\$cache/sub`). The
+consuming layer appends the content prefix, scope, and key on top (see [`store_dir`]). A
+non-`\$` (bare) selector is rejected.
 """
 function selector_root(selector::AbstractString; kwargs...)::String
     s = String(selector)
@@ -317,6 +324,98 @@ function selector_root(selector::AbstractString; kwargs...)::String
     return root
 end
 
+# --- content prefixes and scopes (spec-v3) -----------------------------------
+
+"""
+    content_prefix(kind; storage_config=Dict(), env=ENV) -> String
+
+The per-layer subfolder under a folder root: resolves `DATAMANIFEST_PREFIX_<KIND>` →
+`[_STORAGE._PREFIX].<kind>` → built-in default (`"datasets"` for `:datasets`, `"cached"`
+for `:cached`). `kind` is `:datasets` or `:cached`.
+"""
+function content_prefix(kind; storage_config::AbstractDict=Dict{String,Any}(), env=ENV)::String
+    k = String(kind)
+    envkey = "DATAMANIFEST_PREFIX_$(uppercase(k))"
+    haskey(env, envkey) && return String(env[envkey])
+    p = get(storage_config, "_PREFIX", nothing)
+    if p isa AbstractDict && haskey(p, k)
+        return String(p[k])
+    end
+    return k == "cached" ? "cached" : "datasets"
+end
+
+"""
+    content_scope(kind; storage_config=Dict(), env=ENV, project_root="",
+                  declared_project="") -> String
+
+The optional partition segment controlling sharing: resolves `DATAMANIFEST_SCOPE_<KIND>` →
+`[_STORAGE._SCOPE].<kind>` → built-in default (**empty** for `:datasets` — shared across
+projects; the **project id** for `:cached` — project-isolated). An empty string means no
+scope segment.
+"""
+function content_scope(kind; storage_config::AbstractDict=Dict{String,Any}(), env=ENV,
+                       project_root::AbstractString="", declared_project::AbstractString="")::String
+    k = String(kind)
+    envkey = "DATAMANIFEST_SCOPE_$(uppercase(k))"
+    haskey(env, envkey) && return String(env[envkey])
+    s = get(storage_config, "_SCOPE", nothing)
+    if s isa AbstractDict && haskey(s, k)
+        return String(s[k])
+    end
+    return k == "cached" ? project_id(project_root; declared=declared_project) : ""
+end
+
+# Reduce an arbitrary id to a single path-safe segment.
+_sanitize_segment(s::AbstractString) = replace(String(s), r"[^A-Za-z0-9._-]" => "-")
+
+"""
+    project_id(project_root=""; declared="") -> String
+
+The project id used as the default `cached` scope. First non-empty wins: an explicitly
+`declared` id → the package identity at `project_root` (Julia `uuid` else `name` in
+`Project.toml`) → a hash of the project root's absolute path (machine-local). Rendered to a
+single path-safe segment.
+"""
+function project_id(project_root::AbstractString=""; declared::AbstractString="")::String
+    !isempty(declared) && return _sanitize_segment(declared)
+    pr = isempty(project_root) ? pwd() : String(project_root)
+    ptoml = joinpath(pr, "Project.toml")
+    if isfile(ptoml)
+        try
+            t = TOML.parsefile(ptoml)
+            id = get(t, "uuid", get(t, "name", ""))
+            !isempty(string(id)) && return _sanitize_segment(string(id))
+        catch
+        end
+    end
+    return "p-" * bytes2hex(sha256(abspath(pr)))[1:16]
+end
+
+"""
+    store_dir(selector, kind; project_root="", storage_config=Dict(), env=ENV,
+              host=gethostname(), declared_project="") -> String
+
+Compose the directory **under which a key/cachetype lives** for a given selector and layer
+`kind` (`:datasets` or `:cached`): `selector_root` + content prefix + (non-empty) scope. The
+caller appends the `<key>` (fetch) or `<cachetype>/[<version>/]<hash>` (produce) below it.
+"""
+function store_dir(selector::AbstractString, kind;
+                   project_root::AbstractString="",
+                   storage_config::AbstractDict=Dict{String,Any}(),
+                   env=ENV,
+                   host::AbstractString=gethostname(),
+                   declared_project::AbstractString="")::String
+    root = selector_root(selector; project_root=project_root, storage_config=storage_config,
+                         env=env, host=host)
+    prefix = content_prefix(kind; storage_config=storage_config, env=env)
+    scope = content_scope(kind; storage_config=storage_config, env=env,
+                          project_root=project_root, declared_project=declared_project)
+    p = root
+    !isempty(prefix) && (p = joinpath(p, prefix))
+    !isempty(scope) && (p = joinpath(p, scope))
+    return p
+end
+
 # --- safe-materialization path helpers ---------------------------------------
 
 export tmp_path, lock_path, marker_path, is_complete
@@ -324,26 +423,22 @@ export tmp_path, lock_path, marker_path, is_complete
 """
     tmp_path(target) -> String
 
-Sibling staging path (`<target>.tmp`) a fetcher populates before the atomic
-publish. Always a sibling of `target`, so it never pollutes a directory dataset.
+Sibling staging path (`<target>.tmp`) a fetcher populates before the atomic publish.
 """
 tmp_path(target::AbstractString)::String = string(target, ".tmp")
 
 """
     lock_path(target) -> String
 
-Sibling pidfile-lock path (`<target>.lock`) held while a dataset is being
-materialized.
+Sibling pidfile-lock path (`<target>.lock`) held while a dataset is being materialized.
 """
 lock_path(target::AbstractString)::String = string(target, ".lock")
 
 """
     marker_path(target) -> String
 
-Completion-marker path for `target`: `<target>/.complete` when `target` is a
-directory, `<target>.complete` (a sibling) otherwise. A present marker means the
-entry was fully materialized; its absence means the entry MUST be treated as
-absent (re-fetch), even when `target` itself exists (a partial fetch).
+Completion-marker path for `target`: `<target>/.complete` when `target` is a directory,
+`<target>.complete` (a sibling) otherwise.
 """
 marker_path(target::AbstractString)::String =
     isdir(target) ? joinpath(String(target), ".complete") : string(target, ".complete")
@@ -351,8 +446,8 @@ marker_path(target::AbstractString)::String =
 """
     is_complete(target) -> Bool
 
-`true` iff `target`'s completion marker exists. Readers MUST treat a missing
-marker as absent even when `target` itself is present.
+`true` iff `target`'s completion marker exists. Readers MUST treat a missing marker as
+absent even when `target` itself is present.
 """
 is_complete(target::AbstractString)::Bool = isfile(marker_path(target))
 

--- a/test/conformance_pin.toml
+++ b/test/conformance_pin.toml
@@ -3,11 +3,11 @@
 # The tag + per-file content hashes below are this tool's machine-checkable
 # conformance claim. Hashes are computed from fixture file contents (not the
 # tarball bytes) so the pin stays correct if GitHub re-packs the auto-archive.
-spec_tag = "spec-v2.1"
+spec_tag = "spec-v3"
 
 [files]
-"tests/fixtures/README.md" = "5c1ac5623e2d241859d210559ee79766c08de25b50f0e30dbfe53f0f8c2c0f0a"
-"tests/fixtures/cached_index.expected.json" = "fd87139575fc6069be53e680eab8fa514af7bb7e288f4f606f18e66fcf8b3c89"
+"tests/fixtures/README.md" = "2dbe35bde23eeccea44ebe657ad3760b8d99a937d64d76cd6e0f1f8318afc805"
+"tests/fixtures/cached_index.expected.json" = "2f8ab1ffe68f0e15d5f444568c283cf58eb0456d51f2974155a2dda4ae3548ac"
 "tests/fixtures/cached_index.toml" = "4fb123b0da25e60e6bad9e47ef079639e3899cac006f17d98002f4ba8b7d4da8"
 "tests/fixtures/config_sidecar.expected.json" = "3f3f34e31df88a44f7bd8b598fba93432b286109c7a1bea31953850aca7cbb0b"
 "tests/fixtures/config_sidecar.toml" = "46df73bb0bf0449018107729b9ea2587bc8d1931be1250f076b490eedc5bed98"
@@ -19,7 +19,7 @@ spec_tag = "spec-v2.1"
 "tests/fixtures/single_julia.toml" = "7fae76fba97b995ca4f8bba204323f0aa5d9bc08e410b54ccbece4b55c39370f"
 "tests/fixtures/single_python.expected.json" = "6a41975b5ce5fd9a0f102dfbed55ece48b3779bee4a6922e21edb18f2da58085"
 "tests/fixtures/single_python.toml" = "9bcab1006d357e3a3875c9c07f2d453785528ea14c7f87fd73675a899fa397a3"
-"tests/fixtures/storage.expected.json" = "263bc4fc8d17d7578876ead9640a93b34c474998053f1a37a6fdc8c7aa13fcb5"
-"tests/fixtures/storage.toml" = "43bf51fc6b776551327d04706c99911cf22e452cf55a38cfe2b97f1c96ccf2f8"
+"tests/fixtures/storage.expected.json" = "13eef4e52184694d496c09897f8831a3fe6ecb6f86e8a91c25ec5ed3d68c3ba3"
+"tests/fixtures/storage.toml" = "5a7d7ad0da0df8a6f8e0aec38b9c161484ddd2f3cb8831eec3bfdf235a44adcb"
 "tests/fixtures/unknown_structural.expected.json" = "914001f4d8b6c13911a7f9cbb38ede564a985deb4cca0b1efa55e6996fe08522"
 "tests/fixtures/unknown_structural.toml" = "b794906d29a2d7af6ed1f4edd37d23527bf0890fc693c7811080700f779f3b64"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -766,10 +766,61 @@ try
         @test fn(tmp) == "hello"
         rm(tmp; force=true)
     end
+
+    @testset "Cache (@cached produce-or-load)" begin
+        C = DataManifest.Cache
+
+        # Normative parameter hash: canonical JSON (JCS) → SHA-256 reference vector.
+        kt = Dict("grid" => "5x5", "skip_models" => ["CESM.*", "FGOALS.*"])
+        @test C.canonical_json(kt) == "{\"grid\":\"5x5\",\"skip_models\":[\"CESM.*\",\"FGOALS.*\"]}"
+        @test param_hash(kt) == "83425a30d111562d46c1fce9de7618ea7f1f54e1be72e086cba0ac63c6f2ce9b"
+        # NamedTuple + Symbol coercion + `_`-key exclusion give the same hash.
+        @test param_hash((; grid="5x5", skip_models=["CESM.*", "FGOALS.*"])) == param_hash(kt)
+        @test param_hash((; grid="5x5", skip_models=["CESM.*", "FGOALS.*"], _parallel=true)) == param_hash(kt)
+
+        # Spec-disallowed hash inputs are a hard error (floats, nulls).
+        @test_throws ErrorException param_hash(Dict("x" => 0.15))
+        @test_throws ErrorException param_hash(Dict("x" => nothing))
+
+        # @cached round-trip with an explicit cache_dir (jls), + the on-disk layout.
+        dir = mktempdir()
+        calls = Ref(0)
+        @cached cachetype="demo" key=(a -> (; a.grid, a.n)) function demo(;
+                grid::String="5x5", n::Int=3, _verbose::Bool=false, cache_dir=nothing)
+            calls[] += 1
+            return Dict("grid" => grid, "n" => n, "sum" => n * 2)
+        end
+        r1 = demo(; grid="5x5", n=3, cache_dir=dir)
+        r2 = demo(; grid="5x5", n=3, cache_dir=dir, _verbose=true)  # hit; knob ignored
+        @test calls[] == 1
+        @test r1 == r2
+        hh = param_hash((; grid="5x5", n=3))
+        d = joinpath(dir, "demo", hh)
+        for f in ("data.jls", "config.toml", "metadata.toml", ".complete")
+            @test isfile(joinpath(d, f))
+        end
+        @test C.config_is_valid(d)
+        @test C.read_config(d).cachetype == "demo"
+        @test C.cache_key("demo", hh) == "demo/$hh"
+        # cached=false bypasses disk entirely.
+        demo(; grid="z", n=9, cache_dir=dir, cached=false)
+        @test calls[] == 2
+
+        # Produced datasets are keyword-only: a positional arg is rejected at macro time.
+        kwonly_err = try
+            @eval @cached cachetype="bad" key=(a -> (; a.x)) function _bad_pos(y; x=1)
+                y
+            end
+            ""
+        catch e
+            sprint(showerror, e)
+        end
+        @test occursin("keyword-only", kwonly_err)
+    end
 end
 
-@testset "Conformance suite (spec-v2.1)" begin
-    # Source of truth: github.com/perrette/datamanifest.toml, tag spec-v2.1.
+@testset "Conformance suite (spec-v3)" begin
+    # Source of truth: github.com/perrette/datamanifest.toml, tag spec-v3.
     # The pin file records the spec tag + per-file sha256 of each fixture; hashes
     # are over file contents (not the tarball), keeping the pin robust to GitHub
     # re-generating the auto-archive. The tag + content pin is this tool's
@@ -823,9 +874,12 @@ end
                 end
             end
 
-            # Capabilities this tool implements; drives which fixtures are run
+            # Capabilities this tool implements; drives which fixtures are run.
+            # `cache-produce` = the @cached produce-or-load layer (DataManifest.Cache).
+            # `inspect` / `sync` (cached.toml index + maintenance) are not yet implemented.
             SUPPORTED_CAPABILITIES = Set(["lang-read", "lang-write", "shell-fetch",
-                                          "storage", "binding-args", "byte-identity"])
+                                          "storage", "binding-args", "byte-identity",
+                                          "cache-produce"])
 
             toml_fnames = sort(filter(f -> endswith(f, ".toml"), readdir(fixtures_top)))
             for toml_fname in toml_fnames
@@ -845,6 +899,22 @@ end
                 @testset "Fixture: $base" begin
                     tmp_dir = mktempdir()
                     try
+                        if haskey(expected, "config_sidecar")
+                            # cache-produce: a config.toml sidecar (NOT a datasets.toml).
+                            # Recompute the param hash from the key table (every root key
+                            # except [_META]) and check it equals both the recorded
+                            # _META.hash and the fixture's expected hash + key.
+                            cs = expected["config_sidecar"]
+                            cfg = TOML.parsefile(toml_path)
+                            meta = cfg["_META"]
+                            key_table = Dict{String,Any}(k => v for (k, v) in cfg if k != "_META")
+                            ph = DataManifest.Cache.param_hash(key_table)
+                            @test ph == cs["param_hash"]
+                            @test ph == meta["hash"]
+                            @test String(meta["cachetype"]) == cs["cachetype"]
+                            @test DataManifest.Cache.cache_key(String(meta["cachetype"]), ph) == cs["key"]
+                            @test key_table == Dict{String,Any}(String(k) => v for (k, v) in cs["key_table"])
+                        else
                         db = read_dataset(toml_path, tmp_dir; persist=false)
 
                         # Resolution check: compare model against expected Julia rows
@@ -995,6 +1065,7 @@ end
                         write(db2, tmp_toml2)
                         s2 = read(tmp_toml2, String)
                         @test s1 == s2
+                        end  # config_sidecar vs datasets.toml branch
                     finally
                         rm(tmp_dir; force=true, recursive=true)
                     end


### PR DESCRIPTION
Targets **datamanifest.toml spec-v3** (the spec advanced past the spec-v2.1 that v0.17.0 implemented). Two parts on one branch.

## 1. Storage realignment to spec-v3 (breaking — supersedes the v0.17.0 model)
- Folder variables are **bare top-level roots** (`$data` = `user_data_dir`, no `/Datasets`; `$cache` = `user_cache_dir`; `$repo` = `<project_root>`). The layer applies a lowercase **`datasets/`** content prefix + an optional **scope** → fetched path `<root>/datasets/[<scope>/]<key>`.
- New **`DATAMANIFEST_DIR`** app base; new **`[_STORAGE._PREFIX]`/`[_STORAGE._SCOPE]`** + `DATAMANIFEST_PREFIX_*`/`DATAMANIFEST_SCOPE_*` env. `datasets` scope empty (shared) by default; `cached` scope = project id.
- **`_PROFILE` shelved** (reserved/preserved, not resolved); ladder is env → `_HOST` → base → default.
- **Read-only probe** of the v0.17.0 `…/datamanifest/Datasets` path (and pre-v1.1 `~/.cache/Datasets`) so existing downloads still resolve.

## 2. Produce-or-load (`DataManifest.Cache`, capability `cache-produce`)
- **`@cached`** macro (keyword-only enforced; `cached=` escape hatch; `_`-prefixed runtime knobs + `_metadata_extras` audit channel excluded from the hash). Ported from LGMIO's `@cached`; non-normative surface.
- **Param hash** = SHA-256 of canonical JSON (JCS, RFC 8785) of hash-affecting kwargs — reproduces the spec reference vector `83425a30…`. **Floats/nulls hard-error; positional args rejected.**
- Self-describing artifacts at `<folder>/cached/[<scope>/]<cachetype>/[<version>/]<hash>/` with `config.toml` + `metadata.toml`, via the shared safe-materialization primitive. Default `store="$cache"`.
- Artifact format registry: `jls` built in; register others via `DataManifest.Cache.register_format!`. `Dates`/`Serialization` now deps.

## Validation
- **160 unit tests + 170 conformance assertions** (spec-v3) pass. `config_sidecar` fixture (param-hash re-check) passes; `cached_index` skipped (`inspect` not implemented — a follow-up).

## Notes / flagged inconsistencies (LGMIO `@cached` vs spec)
The macro ergonomics port faithfully, but the spec diverges from LGMIO on: SHA-1+TOML → **SHA-256+canonical-JSON**; **keyword-only** (LGMIO has 4 positional-arg sites); **floats disallowed** in keys (≥6 LGMIO sites); **nulls disallowed**; `config.toml` gains a `[_META]` block; `metadata.toml` field names (`created`/`tool`/`host`/`user`). Adopting the spec strictly would reject those LGMIO patterns — flagged for when LGMIO migrates.

**Deferred (Phase 2):** `cached.toml` index + `inspect` maintenance + `sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)