### PR TITLE
Cross-language fetch (delegation) + spec-v3.3 binding harmonization (v0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.20.0] - 2026-06-03 — spec-v3.3: cross-language fetch (`delegation`) + binding harmonization
+
+Tracks datamanifest.toml **spec-v3.3**. Adds the cross-language fetch rung (capability
+**`delegation`**) and harmonizes binding forms (string|table everywhere). `_META.schema`
+stays **1**. With this release, only **`sync`** remains unimplemented.
+
+### New — cross-language fetch (capability `delegation`)
+
+- **Fetch ladder rung 3.** When a dataset's bytes can be produced only by a foreign-language
+  fetcher (no own `_LANG.julia.fetcher`, no `_LANG.shell.fetcher`, no `uri`, but e.g. a
+  `[<ds>._LANG.python].fetcher`), DataManifest.jl **delegates to the Python `datamanifest`
+  CLI** when it is on `PATH`: it runs `datamanifest download <name>` (pointing the peer at the
+  manifest via `DATAMANIFEST_TOML`), the peer materializes the result in the shared store
+  (verifying `sha256`), and we read it back. Falls through to `uri` when the peer is absent,
+  the call fails, or the dataset sets `delegate = false`. Native (Julia) and `shell` datasets
+  never reach this rung; it applies to fetched datasets only (never produced `@cached` ones).
+
+### Changed — spec-v3.3 binding harmonization (string|table everywhere)
+
+- A **binding** (`fetcher`/`loader`) is now string *or* table at **every** site — including the
+  project-wide `[_LANG.julia.loaders]` map, whose values may now be a `{ ref, args, kwargs }`
+  table (a parameterized format-default loader), not just a `module:function` string.
+- **Canonical write:** a ref-only binding (`{ ref = "M:f" }`) is normalized to the bare string
+  `"M:f"` on write; a binding carrying `args`/`kwargs` is written as a table. (Per-dataset
+  bindings already followed this; project loaders now do too.)
+
+### Conformance
+
+- Targets spec tag **`spec-v3.3`** and declares the **`delegation`** capability (the fixture
+  suite is unchanged from spec-v3.2). 229 unit + 194 conformance tests pass.
+
+### Docs
+
+- README aligned with the spec's annotated [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml) (linked, and the binding snippets drawn from it).
+
 ## [0.19.0] - 2026-06-03 — spec-v3: `cached.toml` index + store maintenance (`inspect`)
 
 Completes the produce-or-load companion layer with the second half of spec-v3: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Changelog
 
-## [0.20.0] - 2026-06-03 — spec-v3.3: cross-language fetch (`delegation`) + binding harmonization
+## [0.20.0] - 2026-06-03 — spec-v3.5: cross-language fetch + language-implicit & bare-shell bindings
 
-Tracks datamanifest.toml **spec-v3.3**. Adds the cross-language fetch rung (capability
-**`delegation`**) and harmonizes binding forms (string|table everywhere). `_META.schema`
-stays **1**. With this release, only **`sync`** remains unimplemented.
+Tracks datamanifest.toml **spec-v3.5**. Adds the cross-language fetch rung (capability
+**`delegation`**), harmonizes binding forms (string|table everywhere), and adds
+**language-implicit (bare) bindings** + the **bare language-agnostic `shell` field**.
+`_META.schema` stays **1**. With this release, only **`sync`** remains unimplemented.
+
+### New — language-implicit bindings (spec-v3.4) + bare `shell` field (spec-v3.5)
+
+- **Bare `fetcher` / `loader`** on a dataset are read as the running tool's **own-language**
+  binding (equivalent to `[<ds>._LANG.julia].fetcher`/`.loader`), and the top-level
+  **`[_LOADERS]`** map is the language-implicit counterpart of `[_LANG.julia.loaders]`. The
+  load/fetch ladders now consult them: own `_LANG.julia` rung → bare rung, with the explicit
+  `_LANG.julia` binding **taking precedence**. A bare binding that fails to resolve in Julia
+  **warns and falls through** (tolerant; never a hard error on that account), and bare
+  bindings are **preserved verbatim** on write (never promoted into `_LANG.julia`).
+- **Bare `shell`** is now a language-agnostic dataset field (the same command for every tool),
+  the canonical form of the shell fetcher; the legacy `[<ds>._LANG.shell].fetcher` is still
+  read. Fetch-ladder rung 2 runs `entry.shell` (else the legacy form).
 
 ### New — cross-language fetch (capability `delegation`)
 
@@ -28,8 +42,9 @@ stays **1**. With this release, only **`sync`** remains unimplemented.
 
 ### Conformance
 
-- Targets spec tag **`spec-v3.3`** and declares the **`delegation`** capability (the fixture
-  suite is unchanged from spec-v3.2). 229 unit + 194 conformance tests pass.
+- Targets spec tag **`spec-v3.5`** and declares the **`delegation`** capability; validates
+  the new `lang_implicit` fixture (bare bindings + `[_LOADERS]`) and the updated `multilang`
+  fixture (bare `shell` field). 229 unit + 231 conformance tests pass.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,23 @@
 # Changelog
 
-## [0.20.0] - 2026-06-03 — spec-v3.5: cross-language fetch + language-implicit & bare-shell bindings
+## [0.20.0] - 2026-06-03 — spec-v3.6: cross-language fetch + language-implicit & bare-shell bindings
 
-Tracks datamanifest.toml **spec-v3.5**. Adds the cross-language fetch rung (capability
+Tracks datamanifest.toml **spec-v3.6**. Adds the cross-language fetch rung (capability
 **`delegation`**), harmonizes binding forms (string|table everywhere), and adds
 **language-implicit (bare) bindings** + the **bare language-agnostic `shell` field**.
 `_META.schema` stays **1**. With this release, only **`sync`** remains unimplemented.
 
-### New — language-implicit bindings (spec-v3.4) + bare `shell` field (spec-v3.5)
+### New — language-implicit bindings (spec-v3.4/3.6) + bare `shell` field (spec-v3.5)
 
 - **Bare `fetcher` / `loader`** on a dataset are read as the running tool's **own-language**
   binding (equivalent to `[<ds>._LANG.julia].fetcher`/`.loader`), and the top-level
   **`[_LOADERS]`** map is the language-implicit counterpart of `[_LANG.julia.loaders]`. The
   load/fetch ladders now consult them: own `_LANG.julia` rung → bare rung, with the explicit
-  `_LANG.julia` binding **taking precedence**. A bare binding that fails to resolve in Julia
-  **warns and falls through** (tolerant; never a hard error on that account), and bare
-  bindings are **preserved verbatim** on write (never promoted into `_LANG.julia`).
+  `_LANG.julia` binding **taking precedence**. A bare binding is **present** for Julia, so
+  (spec-v3.6) it is treated exactly like an explicit `_LANG.julia` binding — **fail loud**: a
+  resolution failure errors and a runtime error propagates, never a silent fall-through to a
+  different loader/fetcher; the ladder only skips bindings that are **absent** for Julia.
+  Bare bindings are **preserved verbatim** on write (never promoted into `_LANG.julia`).
 - **Bare `shell`** is now a language-agnostic dataset field (the same command for every tool),
   the canonical form of the shell fetcher; the legacy `[<ds>._LANG.shell].fetcher` is still
   read. Fetch-ladder rung 2 runs `entry.shell` (else the legacy form).
@@ -42,9 +44,9 @@ Tracks datamanifest.toml **spec-v3.5**. Adds the cross-language fetch rung (capa
 
 ### Conformance
 
-- Targets spec tag **`spec-v3.5`** and declares the **`delegation`** capability; validates
+- Targets spec tag **`spec-v3.6`** and declares the **`delegation`** capability; validates
   the new `lang_implicit` fixture (bare bindings + `[_LOADERS]`) and the updated `multilang`
-  fixture (bare `shell` field). 229 unit + 231 conformance tests pass.
+  fixture (bare `shell` field). 235 unit + 231 conformance tests pass.
 
 ### Docs
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataManifest"
 uuid = "b8ee69ef-a20a-4d38-bceb-a68d72817f72"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Mahé Perrette <mahe.perrette@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A `"Module:function"` ref is resolved at runtime by `using Module` followed by `
 
 **Bindings are string or table** at every site (spec-v3.3) — a bare `module:function` string, or a `{ ref, args, kwargs }` table — including the project-wide `[_LANG.julia.loaders]` map, so a format default can be parameterized exactly like a per-dataset loader.
 
-**Language-implicit (bare) bindings** (spec-v3.4): for a single-language project you may skip the `_LANG.julia` wrapper and write a bare `fetcher`/`loader` directly on the dataset (and a top-level `[_LOADERS]` format map) — read as the running tool's **own-language** binding. An explicit `_LANG.julia` binding takes precedence; a bare binding that doesn't resolve in Julia warns and falls through. The **`shell`** field is the language-*agnostic* sibling (spec-v3.5) — the same command for every tool. Foreign `_LANG.<other>` subtrees, bare bindings, `[_LOADERS]`, and unknown `_*` tables all round-trip verbatim; only the Julia `_LANG` subtree is regenerated from the model.
+**Language-implicit (bare) bindings** (spec-v3.4): for a single-language project you may skip the `_LANG.julia` wrapper and write a bare `fetcher`/`loader` directly on the dataset (and a top-level `[_LOADERS]` format map) — read as the running tool's **own-language** binding. An explicit `_LANG.julia` binding takes precedence. A bare binding is *present* for Julia, so it is treated like an explicit one — **fail loud** (spec-v3.6): a resolution failure errors and a runtime error propagates, never a silent fall-through; the ladder only skips bindings *absent* for Julia (another language's `_LANG.<other>`). The **`shell`** field is the language-*agnostic* sibling (spec-v3.5) — the same command for every tool. Foreign `_LANG.<other>` subtrees, bare bindings, `[_LOADERS]`, and unknown `_*` tables all round-trip verbatim; only the Julia `_LANG` subtree is regenerated from the model.
 
 ### Parameterized bindings
 
@@ -235,7 +235,7 @@ end
 
 ## Conformance
 
-This release targets the **datamanifest.toml spec tag `spec-v3.5`** (source of truth: <https://github.com/perrette/datamanifest.toml>). A complete, annotated example manifest lives there: [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml).
+This release targets the **datamanifest.toml spec tag `spec-v3.6`** (source of truth: <https://github.com/perrette/datamanifest.toml>). A complete, annotated example manifest lives there: [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml).
 
 Implemented capabilities: **`lang-read`**, **`lang-write`**, **`shell-fetch`**, **`storage`**, **`binding-args`**, **`byte-identity`**, **`cache-produce`**, **`inspect`**, **`delegation`**. Only **`sync`** (cross-machine `push`/`pull`) is not yet implemented.
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,20 @@ nc  = "NCDatasets:Dataset"
 loader = "MyClimate:load_argo"
 
 # A dataset with no public URI: produced by a fetcher. The own-language fetcher runs
-# in-process; the shell fetcher is a cheap cross-language fallback that writes $download_path.
+# in-process; the bare, language-agnostic `shell` command is the same for every tool
+# and writes to $download_path.
+[model_output]
+format = "nc"
+shell  = "make model_output OUTPUT=$download_path"
+
 [model_output._LANG.julia]
 fetcher = "MyClimate:build_model_output"
-[model_output._LANG.shell]
-fetcher = "make model_output OUTPUT=$download_path"
+
+# Single-language shorthand: a bare `loader` (no `_LANG` wrapper) is read as Julia's own.
+[sea_ice]
+uri    = "https://example.com/sea_ice.nc"
+format = "nc"
+loader = "MyClimate:load_sea_ice"
 ```
 
 A `"Module:function"` ref is resolved at runtime by `using Module` followed by `getfield(Module, :function)` — no `eval`, no `include_string`.

--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ fetcher = "make model_output OUTPUT=$download_path"
 
 A `"Module:function"` ref is resolved at runtime by `using Module` followed by `getfield(Module, :function)` — no `eval`, no `include_string`.
 
-**Fetch ladder** (per dataset, in order): own `_LANG.julia.fetcher` → `_LANG.shell.fetcher` (shell template) → **cross-language fetch (rung 3)** → `uri`/`uris` → error. Rung 3 is the rare case where a dataset's bytes can be produced only by a foreign-language fetcher (e.g. `[<ds>._LANG.python].fetcher`): DataManifest.jl delegates to the Python `datamanifest` CLI when it is on `PATH` (`datamanifest download <name>`), which materializes the result in the shared store; it falls through to `uri` when the peer is absent, disabled (`delegate = false`), or fails.
+**Fetch ladder** (per dataset, in order): own `_LANG.julia.fetcher` (or the bare `fetcher`) → the dataset's `shell` command → **cross-language fetch (rung 3)** → `uri`/`uris` → error. Rung 3 is the rare case where a dataset's bytes can be produced only by a foreign-language fetcher (e.g. `[<ds>._LANG.python].fetcher`): DataManifest.jl delegates to the Python `datamanifest` CLI when it is on `PATH` (`datamanifest download <name>`), which materializes the result in the shared store; it falls through to `uri` when the peer is absent, disabled (`delegate = false`), or fails.
 
-**Load ladder** (per dataset, in order): own `_LANG.julia.loader` → manifest `[_LANG.julia.loaders][format]` → built-in format default → error. Never spawns a subprocess.
+**Load ladder** (per dataset, in order): own `_LANG.julia.loader` (or the bare `loader`) → manifest `[_LANG.julia.loaders][format]` (or `[_LOADERS][format]`) → built-in format default → error. Never spawns a subprocess.
 
-Bindings are **string or table** at every site (spec-v3.3) — a bare `module:function` string, or a `{ ref, args, kwargs }` table — including the project-wide `[_LANG.julia.loaders]` map, so a format default can be parameterized exactly like a per-dataset loader. Foreign `_LANG.<other>` subtrees (e.g. `[bar._LANG.python]`) and unknown `_*` top-level tables are carried through verbatim on every read→write cycle; only the Julia subtree is regenerated from the model.
+**Bindings are string or table** at every site (spec-v3.3) — a bare `module:function` string, or a `{ ref, args, kwargs }` table — including the project-wide `[_LANG.julia.loaders]` map, so a format default can be parameterized exactly like a per-dataset loader.
+
+**Language-implicit (bare) bindings** (spec-v3.4): for a single-language project you may skip the `_LANG.julia` wrapper and write a bare `fetcher`/`loader` directly on the dataset (and a top-level `[_LOADERS]` format map) — read as the running tool's **own-language** binding. An explicit `_LANG.julia` binding takes precedence; a bare binding that doesn't resolve in Julia warns and falls through. The **`shell`** field is the language-*agnostic* sibling (spec-v3.5) — the same command for every tool. Foreign `_LANG.<other>` subtrees, bare bindings, `[_LOADERS]`, and unknown `_*` tables all round-trip verbatim; only the Julia `_LANG` subtree is regenerated from the model.
 
 ### Parameterized bindings
 
@@ -233,7 +235,7 @@ end
 
 ## Conformance
 
-This release targets the **datamanifest.toml spec tag `spec-v3.3`** (source of truth: <https://github.com/perrette/datamanifest.toml>). A complete, annotated example manifest lives there: [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml).
+This release targets the **datamanifest.toml spec tag `spec-v3.5`** (source of truth: <https://github.com/perrette/datamanifest.toml>). A complete, annotated example manifest lives there: [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml).
 
 Implemented capabilities: **`lang-read`**, **`lang-write`**, **`shell-fetch`**, **`storage`**, **`binding-args`**, **`byte-identity`**, **`cache-produce`**, **`inspect`**, **`delegation`**. Only **`sync`** (cross-machine `push`/`pull`) is not yet implemented.
 

--- a/README.md
+++ b/README.md
@@ -71,39 +71,49 @@ See the [full documentation](/docs/doc.md) and the [API](/docs/api.md).
 
 ## Per-language bindings (`_LANG`)
 
-Custom fetch and load logic lives in a dedicated `_LANG` namespace, so a single manifest can serve multiple language implementations without conflicts. Bindings are `module:function` references — never inline code:
+Custom fetch and load logic lives in a dedicated `_LANG` namespace, so a single manifest can serve multiple language implementations without conflicts. Bindings are `module:function` references — never inline code (the snippets below are drawn from the spec's [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml)):
 
 ```toml
 [_META]
 schema = 1
 
+# Project-wide default loaders, per language: format -> binding.
 [_LANG.julia.loaders]
-nc = "MyProject:load_netcdf"          # per-format default loader for this manifest
+csv = "CSV:read"
+nc  = "NCDatasets:Dataset"
 
-[my_dataset._LANG.julia]
-fetcher = "MyFetchers:fetch_my_data"  # called instead of the built-in URI download
-loader  = "MyLoaders:load_my_data"    # called instead of the format default
+# A per-dataset loader override (overrides the nc format default for this dataset only).
+[ocean_temp._LANG.julia]
+loader = "MyClimate:load_argo"
+
+# A dataset with no public URI: produced by a fetcher. The own-language fetcher runs
+# in-process; the shell fetcher is a cheap cross-language fallback that writes $download_path.
+[model_output._LANG.julia]
+fetcher = "MyClimate:build_model_output"
+[model_output._LANG.shell]
+fetcher = "make model_output OUTPUT=$download_path"
 ```
 
 A `"Module:function"` ref is resolved at runtime by `using Module` followed by `getfield(Module, :function)` — no `eval`, no `include_string`.
 
-**Fetch ladder** (per dataset, in order): own `_LANG.julia.fetcher` → `_LANG.shell.fetcher` (shell template) → `uri`/`uris` → error. Delegation to peer CLIs is not yet implemented.
+**Fetch ladder** (per dataset, in order): own `_LANG.julia.fetcher` → `_LANG.shell.fetcher` (shell template) → **cross-language fetch (rung 3)** → `uri`/`uris` → error. Rung 3 is the rare case where a dataset's bytes can be produced only by a foreign-language fetcher (e.g. `[<ds>._LANG.python].fetcher`): DataManifest.jl delegates to the Python `datamanifest` CLI when it is on `PATH` (`datamanifest download <name>`), which materializes the result in the shared store; it falls through to `uri` when the peer is absent, disabled (`delegate = false`), or fails.
 
 **Load ladder** (per dataset, in order): own `_LANG.julia.loader` → manifest `[_LANG.julia.loaders][format]` → built-in format default → error. Never spawns a subprocess.
 
-Foreign `_LANG.<other>` subtrees (e.g. `[bar._LANG.python]`) and unknown `_*` top-level tables are carried through verbatim on every read→write cycle; only the Julia subtree is regenerated from the model.
+Bindings are **string or table** at every site (spec-v3.3) — a bare `module:function` string, or a `{ ref, args, kwargs }` table — including the project-wide `[_LANG.julia.loaders]` map, so a format default can be parameterized exactly like a per-dataset loader. Foreign `_LANG.<other>` subtrees (e.g. `[bar._LANG.python]`) and unknown `_*` top-level tables are carried through verbatim on every read→write cycle; only the Julia subtree is regenerated from the model.
 
 ### Parameterized bindings
 
-Fetcher and loader refs can carry `args`/`kwargs` for more flexible dispatch — reusing one function across datasets that differ only in arguments:
+A binding's **table form** carries `args`/`kwargs`, reusing one function across datasets that differ only in arguments:
 
 ```toml
-[my_dataset._LANG.julia]
-fetcher = { ref = "MyFetchers:fetch", args = ["$download_path"], kwargs = { format = "nc" } }
-loader  = { ref = "MyLoaders:load",  args = ["$path"],           kwargs = { grid = "5x5" } }
+[esm_5x5._LANG.julia.loader]
+ref    = "MyClimate:load_esm"
+args   = ["$path"]
+kwargs = { grid = "5x5", skip_models = ["CESM.*"] }
 ```
 
-At call time, `$var` placeholders in string values are substituted with the dataset's context variables (`$download_path` / `$path`, `$key`, `$uri`, `$version`, `$doi`, `$format`, `$branch`, `$project_root`) and the function is called as `ref(args...; kwargs...)`. Bare-string bindings (`fetcher = "Mod:fn"`) keep the conventional keyword-argument call.
+At call time, `$var` placeholders in string values are substituted with the dataset's context variables (`$download_path` / `$path`, `$key`, `$uri`, `$version`, `$doi`, `$format`, `$branch`, `$project_root`) and the function is called as `ref(args...; kwargs...)`. A ref-only binding — the bare string `"Mod:fn"`, equivalently `{ ref = "Mod:fn" }` — keeps the conventional call and is written back as the string.
 
 ### Migration
 
@@ -223,11 +233,11 @@ end
 
 ## Conformance
 
-This release targets the **datamanifest.toml spec tag `spec-v3.2`** (source of truth: <https://github.com/perrette/datamanifest.toml>).
+This release targets the **datamanifest.toml spec tag `spec-v3.3`** (source of truth: <https://github.com/perrette/datamanifest.toml>). A complete, annotated example manifest lives there: [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml).
 
-Implemented capabilities: **`lang-read`**, **`lang-write`**, **`shell-fetch`**, **`storage`**, **`binding-args`**, **`byte-identity`**, **`cache-produce`**, **`inspect`**. Only **`sync`** (cross-machine `push`/`pull`) is not yet implemented.
+Implemented capabilities: **`lang-read`**, **`lang-write`**, **`shell-fetch`**, **`storage`**, **`binding-args`**, **`byte-identity`**, **`cache-produce`**, **`inspect`**, **`delegation`**. Only **`sync`** (cross-machine `push`/`pull`) is not yet implemented.
 
-The test suite downloads the spec's tagged tarball, verifies every fixture file against a pinned per-file sha256 map (`test/conformance_pin.toml`), and runs only the fixtures whose capability set is a subset of the above. Fixtures requiring unimplemented capabilities (e.g. delegation) are skipped with a logged reason.
+The test suite downloads the spec's tagged tarball, verifies every fixture file against a pinned per-file sha256 map (`test/conformance_pin.toml`), and runs only the fixtures whose capability set is a subset of the above. Fixtures requiring unimplemented capabilities (e.g. `sync`) are skipped with a logged reason.
 
 ## Roadmap
 

--- a/src/Databases.jl
+++ b/src/Databases.jl
@@ -247,9 +247,10 @@ mutable struct Database
     extra::Dict{String,Any}
     # Schema version from `[_META].schema`; `nothing` ⇒ v0 (legacy flat).
     schema::Union{Int,Nothing}
-    # Own v1 default loaders parsed from `[_LANG.julia.loaders]`: a
-    # `format → module:function` ref map. Empty ⇒ none declared.
-    lang_julia_loaders::Dict{String,String}
+    # Own v1 default loaders parsed from `[_LANG.julia.loaders]`: a `format → binding`
+    # map (spec-v3.3 — each binding is a `module:function` string or a `{ ref, args,
+    # kwargs }` table, exactly like a per-dataset loader). Empty ⇒ none declared.
+    lang_julia_loaders::Dict{String,Any}
     # Parsed copy of `[_STORAGE]` for the path resolver; verbatim copy stays in
     # `extra` for lossless round-trip. Empty when `[_STORAGE]` is absent.
     storage_config::Dict{String,Any}
@@ -266,7 +267,7 @@ mutable struct Database
             loader_context_module::Union{Module,Nothing},
             extra::Dict{String,Any}=Dict{String,Any}(),
             schema::Union{Int,Nothing}=nothing,
-            lang_julia_loaders::Dict{String,String}=Dict{String,String}(),
+            lang_julia_loaders::Dict{String,Any}=Dict{String,Any}(),
             storage_config::Dict{String,Any}=Dict{String,Any}())
         new(datasets, datasets_toml, datasets_folder, skip_checksum, skip_checksum_folders,
             loaders, loaders_julia_modules, loaders_julia_includes, loader_cache, loader_context_module,
@@ -311,8 +312,12 @@ function to_dict(db::Database; kwargs...)
     # map) from the parsed model and merge it with any foreign top-level
     # `[_LANG.<other>]` kept verbatim in `db.extra` (already spliced above).
     if !isempty(db.lang_julia_loaders)
+        # Canonical write (spec-v3.3): a ref-only binding emits the bare string, a
+        # parameterized one a `{ ref, args, kwargs }` table — via the same normalization
+        # as per-dataset bindings.
         julia_block = Dict{String,Any}(
-            "loaders" => Dict{String,Any}(k => v for (k, v) in db.lang_julia_loaders),
+            "loaders" => Dict{String,Any}(
+                k => _binding_to_dict(_parse_binding(v)...) for (k, v) in db.lang_julia_loaders),
         )
         lang = (haskey(result, "_LANG") && result["_LANG"] isa AbstractDict) ?
             copy(result["_LANG"]) : Dict{String,Any}()
@@ -714,9 +719,13 @@ function _parse_database_lang!(db::Database)
     if julia isa AbstractDict
         loaders = get(julia, "loaders", nothing)
         if loaders isa AbstractDict
-            for (fmt, ref) in loaders
-                if ref isa AbstractString
-                    db.lang_julia_loaders[String(fmt)] = String(ref)
+            for (fmt, b) in loaders
+                # spec-v3.3: a project loader is a binding (string or `{ ref, … }` table);
+                # keep it raw for lossless round-trip + parameterized resolution.
+                if b isa AbstractString
+                    db.lang_julia_loaders[String(fmt)] = String(b)
+                elseif b isa AbstractDict
+                    db.lang_julia_loaders[String(fmt)] = Dict{String,Any}(String(k) => v for (k, v) in b)
                 end
             end
         end

--- a/src/PipeLines.jl
+++ b/src/PipeLines.jl
@@ -5,7 +5,7 @@ import Downloads
 using ..Config: info, COMPRESSED_FORMATS
 using ..Databases: DatasetEntry, Database, get_datasets, get_dataset_path, resolve_existing_path,
     search_dataset, verify_checksum,
-    extract_file, get_project_root, get_default_database, parse_uri_metadata
+    extract_file, get_project_root, get_default_database, parse_uri_metadata, _parse_binding
 using ..Storage: tmp_path, lock_path, marker_path, is_complete
 using ..DefaultLoaders: default_loader as builtin_default_loader
 
@@ -306,6 +306,57 @@ function _lang_shell_fetcher(entry::DatasetEntry)::String
     return f isa AbstractString ? String(f) : ""
 end
 
+# ----- Cross-language fetch (fetch ladder rung 3): delegate to the peer CLI -----
+# The rare case: a dataset's bytes can be produced only by a fetcher defined in another
+# language (no own Julia fetcher, no shell fetcher, no `uri`). The Python `datamanifest` is
+# the reference peer and aims to cover every language, so we invoke it: it resolves its own
+# store (matching ours by default) and materializes the result there, which our
+# read-resolution then finds. Falls through to the normal path (→ a clear "no fetcher"
+# error) when delegation is disabled, the CLI is absent, or the call fails.
+
+const PEER_CLI = "datamanifest"
+
+# Languages other than julia/shell that declare a `fetcher` for this dataset — i.e. a
+# foreign fetcher only the peer CLI can run.
+function _foreign_fetcher_langs(entry::DatasetEntry)::Vector{String}
+    lang = get(entry.extra, "_LANG", nothing)
+    lang isa AbstractDict || return String[]
+    out = String[]
+    for (k, v) in lang
+        ks = String(k)
+        (ks == "julia" || ks == "shell") && continue
+        v isa AbstractDict && haskey(v, "fetcher") && push!(out, ks)
+    end
+    return out
+end
+
+# Whether to attempt cross-language delegation for this dataset. The optional `delegate`
+# field forces it on/off; absent, it defaults on — delegation is the only way to fetch a
+# foreign-only dataset, so the alternative is a hard "no fetcher" error.
+function _should_delegate(entry::DatasetEntry)::Bool
+    d = get(entry.extra, "delegate", nothing)
+    return d isa Bool ? d : true
+end
+
+# Run `datamanifest download <name>`, pointing the peer at our manifest via
+# `DATAMANIFEST_TOML`. The peer writes into the shared store (verifying `sha256`) and exits
+# non-zero on failure. Returns true on a zero exit; false when the CLI is absent / no
+# manifest on disk / the call fails.
+function _delegate_fetch(db::Database, name::AbstractString)::Bool
+    (Sys.which(PEER_CLI) === nothing) && return false
+    isempty(db.datasets_toml) && return false
+    env = copy(ENV)
+    env["DATAMANIFEST_TOML"] = abspath(db.datasets_toml)
+    try
+        info("Cross-language fetch: delegating \"$name\" to the peer CLI (`$PEER_CLI download`)")
+        run(setenv(`$PEER_CLI download $name`, env))
+        return true
+    catch e
+        info("Peer-CLI fetch for \"$name\" failed; falling through ($(sprint(showerror, e)))")
+        return false
+    end
+end
+
 # Expand and run a shell fetch template. Shared by the v0 `shell=` field and the
 # v1 `_LANG.shell.fetcher` rung so both behave identically.
 function _run_shell(template::String, dataset::DatasetEntry, download_path::String, project_root::String;
@@ -574,6 +625,25 @@ function download_dataset(db::Database, dataset::DatasetEntry; extract::Union{No
     end
 
     did_fetch = false
+
+    # Fetch ladder rung 3 — cross-language fetch (the rare case): no own Julia fetcher, no
+    # shell fetcher, no `uri`, but a foreign-language fetcher exists. Delegate to the peer
+    # `datamanifest` CLI, which materializes the result in the shared store; we then read it.
+    if db.schema == 1 && (overwrite || !(isfile(download_path) || isdir(download_path))) &&
+       dataset.lang_julia_fetcher == "" && _lang_shell_fetcher(dataset) == "" &&
+       isempty(dataset.uris) && dataset.uri == "" &&
+       _should_delegate(dataset) && !isempty(_foreign_fetcher_langs(dataset))
+        if _delegate_fetch(db, name)
+            existing = resolve_existing_path(db, dataset; extract=extract)
+            if isfile(existing) || isdir(existing)
+                info("Dataset fetched via peer CLI: $existing")
+                verify_checksum(db, dataset; extract=extract, skip_if_complete=true)
+                return existing
+            end
+        end
+        # delegation off/unavailable/failed → fall through (the path below errors clearly).
+    end
+
     if overwrite || !(isfile(download_path) || isdir(download_path))
         info("Downloading dataset: $(dataset.uri) to $download_path")
         project_root = get_project_root(db)
@@ -674,8 +744,23 @@ function _resolve_loader_v1(db::Database, entry::DatasetEntry)
     format = (entry.extract && entry.format in COMPRESSED_FORMATS) ? "" : entry.format
     fmt = lowercase(strip(format))
     if !isempty(fmt)
-        for (k, ref) in pairs(db.lang_julia_loaders)
-            lowercase(strip(k)) == fmt && return _resolve_ref(db, ref)
+        for (k, b) in pairs(db.lang_julia_loaders)
+            if lowercase(strip(k)) == fmt
+                # spec-v3.3: a project loader is a binding (string or `{ ref, args, kwargs }`).
+                ref, args, kwargs = _parse_binding(b)
+                isempty(ref) && error("Project loader for format \"$fmt\" has no `ref`.")
+                fn = _resolve_ref(db, ref)
+                if isempty(args) && isempty(kwargs)
+                    return fn   # ref-only: conventional call fn(path)
+                end
+                # Parameterized: substitute `$var` (incl. `$path`) and call ref(args...; kwargs...).
+                return function (path)
+                    subs = _binding_subst_pairs(entry, "\$path" => path, get_project_root(db))
+                    a = _subst_binding_value(args, subs)
+                    kw = _kwargs_pairs(_subst_binding_value(kwargs, subs))
+                    return Base.invokelatest(fn, a...; kw...)
+                end
+            end
         end
     end
     if isempty(fmt)

--- a/src/PipeLines.jl
+++ b/src/PipeLines.jl
@@ -306,10 +306,11 @@ function _lang_shell_fetcher(entry::DatasetEntry)::String
     return f isa AbstractString ? String(f) : ""
 end
 
-# ----- Language-implicit (bare) fetcher (spec-v3.4) -----
+# ----- Language-implicit (bare) fetcher (spec-v3.4/3.6) -----
 # A dataset MAY carry a bare `fetcher` binding read as the running tool's own language
 # (equivalent to `[<ds>._LANG.julia].fetcher`). Explicit `_LANG.julia.fetcher` wins; a bare
-# fetcher that fails to resolve in Julia warns and falls through (tolerant).
+# fetcher is **present** for Julia ⇒ spec-v3.6 fail-loud: it resolves-or-errors and a runtime
+# error propagates (never a silent fall-through to the next rung).
 
 # The bare fetcher's `module:function` ref (string or `{ ref … }` table), or "" when absent.
 function _bare_fetcher_ref(entry::DatasetEntry)::String
@@ -323,24 +324,18 @@ function _bare_fetcher_ref(entry::DatasetEntry)::String
 end
 
 # Resolve + run a bare fetcher `ref` as the own-language fetcher (conventional keyword-arg
-# call, like the bare-string `_LANG.julia.fetcher`). Returns true when it ran; false when the
-# ref does not resolve in Julia (→ warn and fall through to the next rung).
+# call, like the bare-string `_LANG.julia.fetcher`). Present-for-Julia ⇒ a resolution or
+# runtime failure propagates (spec-v3.6 fail-loud).
 function _run_bare_fetcher(db::Database, dataset::DatasetEntry, ref::String,
                           download_path::String, project_root::String;
-                          required_paths_ordered::Vector{String}=String[])::Bool
-    local fn
-    try
-        fn = _resolve_ref(db, ref)
-    catch e
-        @warn "Bare `fetcher` did not resolve in Julia; falling through" ref = ref exception = e
-        return false
-    end
+                          required_paths_ordered::Vector{String}=String[])
+    fn = _resolve_ref(db, ref)
     call = () -> Base.invokelatest(fn;
         download_path=download_path, project_root=project_root, entry=dataset,
         uri=dataset.uri, key=dataset.key, version=dataset.version, doi=dataset.doi,
         format=dataset.format, branch=dataset.branch, requires_paths=required_paths_ordered)
     project_root != "" ? cd(call, project_root) : call()
-    return true
+    return nothing
 end
 
 # The dataset's shell fetcher command (spec-v3.5): the bare, language-agnostic `shell` field,
@@ -524,9 +519,10 @@ function _download_dataset(dataset::DatasetEntry, download_path::String; project
             return
         end
         bare_fetcher = _bare_fetcher_ref(dataset)
-        if bare_fetcher != "" &&
-           _run_bare_fetcher(db, dataset, bare_fetcher, download_path, project_root;
-                            required_paths_ordered=required_paths_ordered)
+        if bare_fetcher != ""
+            # present-for-Julia ⇒ commit to it (resolution/runtime errors propagate).
+            _run_bare_fetcher(db, dataset, bare_fetcher, download_path, project_root;
+                             required_paths_ordered=required_paths_ordered)
             return
         end
         # rung 2 — the dataset's `shell` command (bare field, else legacy `_LANG.shell`).
@@ -798,25 +794,20 @@ function _loader_from_binding(db::Database, entry::DatasetEntry, b)
     end
 end
 
-# v1 load ladder (spec-v3.4):
+# v1 load ladder (spec-v3.4/3.6):
 #   1. own `[<ds>._LANG.julia].loader`, else the bare (language-implicit) `loader`;
 #   2. `[_LANG.julia.loaders][format]`, else `[_LOADERS][format]` (language-implicit);
 #   3. built-in format default; else error.
-# At each own-language rung the explicit `_LANG.julia` binding wins over the bare one; a bare
-# binding that fails to resolve in Julia warns and falls through (tolerant, never a hard
-# error on that account). A v1 loader never spawns a subprocess / never `include_string`s.
+# At each own-language rung the explicit `_LANG.julia` binding wins over the bare one. A
+# binding that is **present** for Julia (bare or explicit) is treated alike: spec-v3.6 —
+# **fail loud**, it resolves-or-errors, and a runtime error propagates; the ladder falls
+# through only past **absent** bindings, never to paper over a broken present one. A v1
+# loader never spawns a subprocess / never `include_string`s.
 function _resolve_loader_v1(db::Database, entry::DatasetEntry)
-    # rung 1 — explicit own loader, else the bare language-implicit loader.
-    if entry.lang_julia_loader != ""
-        return _loader_from_binding(db, entry, entry.lang_julia_loader)
-    end
-    if entry.loader != ""
-        try
-            return _loader_from_binding(db, entry, entry.loader)
-        catch e
-            @warn "Bare `loader` did not resolve in Julia; falling through to format defaults" ref = entry.loader exception = e
-        end
-    end
+    # rung 1 — explicit own loader, else the bare language-implicit loader (both present-for-
+    # Julia ⇒ resolve-or-error, no silent fall-through).
+    entry.lang_julia_loader != "" && return _loader_from_binding(db, entry, entry.lang_julia_loader)
+    entry.loader != "" && return _loader_from_binding(db, entry, entry.loader)
     # For extracted archives, path is a directory; no single-file format to load.
     format = (entry.extract && entry.format in COMPRESSED_FORMATS) ? "" : entry.format
     fmt = lowercase(strip(format))
@@ -826,13 +817,7 @@ function _resolve_loader_v1(db::Database, entry::DatasetEntry)
             lowercase(strip(k)) == fmt && return _loader_from_binding(db, entry, b)
         end
         for (k, b) in pairs(db.loaders)
-            if lowercase(strip(k)) == fmt
-                try
-                    return _loader_from_binding(db, entry, b)
-                catch e
-                    @warn "Bare `[_LOADERS]` loader did not resolve in Julia; falling through" format = fmt exception = e
-                end
-            end
+            lowercase(strip(k)) == fmt && return _loader_from_binding(db, entry, b)
         end
     end
     # rung 3 — built-in format default.

--- a/src/PipeLines.jl
+++ b/src/PipeLines.jl
@@ -306,6 +306,48 @@ function _lang_shell_fetcher(entry::DatasetEntry)::String
     return f isa AbstractString ? String(f) : ""
 end
 
+# ----- Language-implicit (bare) fetcher (spec-v3.4) -----
+# A dataset MAY carry a bare `fetcher` binding read as the running tool's own language
+# (equivalent to `[<ds>._LANG.julia].fetcher`). Explicit `_LANG.julia.fetcher` wins; a bare
+# fetcher that fails to resolve in Julia warns and falls through (tolerant).
+
+# The bare fetcher's `module:function` ref (string or `{ ref … }` table), or "" when absent.
+function _bare_fetcher_ref(entry::DatasetEntry)::String
+    f = get(entry.extra, "fetcher", nothing)
+    f isa AbstractString && return String(f)
+    if f isa AbstractDict
+        r = get(f, "ref", nothing)
+        return r isa AbstractString ? String(r) : ""
+    end
+    return ""
+end
+
+# Resolve + run a bare fetcher `ref` as the own-language fetcher (conventional keyword-arg
+# call, like the bare-string `_LANG.julia.fetcher`). Returns true when it ran; false when the
+# ref does not resolve in Julia (→ warn and fall through to the next rung).
+function _run_bare_fetcher(db::Database, dataset::DatasetEntry, ref::String,
+                          download_path::String, project_root::String;
+                          required_paths_ordered::Vector{String}=String[])::Bool
+    local fn
+    try
+        fn = _resolve_ref(db, ref)
+    catch e
+        @warn "Bare `fetcher` did not resolve in Julia; falling through" ref = ref exception = e
+        return false
+    end
+    call = () -> Base.invokelatest(fn;
+        download_path=download_path, project_root=project_root, entry=dataset,
+        uri=dataset.uri, key=dataset.key, version=dataset.version, doi=dataset.doi,
+        format=dataset.format, branch=dataset.branch, requires_paths=required_paths_ordered)
+    project_root != "" ? cd(call, project_root) : call()
+    return true
+end
+
+# The dataset's shell fetcher command (spec-v3.5): the bare, language-agnostic `shell` field,
+# else the legacy `[<ds>._LANG.shell].fetcher`. "" when neither is present.
+_shell_command(entry::DatasetEntry)::String =
+    entry.shell != "" ? entry.shell : _lang_shell_fetcher(entry)
+
 # ----- Cross-language fetch (fetch ladder rung 3): delegate to the peer CLI -----
 # The rare case: a dataset's bytes can be produced only by a fetcher defined in another
 # language (no own Julia fetcher, no shell fetcher, no `uri`). The Python `datamanifest` is
@@ -475,21 +517,29 @@ function _download_dataset(dataset::DatasetEntry, download_path::String; project
     # uri rung falls through to the uris/scheme handling below, and the absence of
     # every rung is a clear error.
     if v1
+        # rung 1 — own `_LANG.julia.fetcher`, else the bare (language-implicit) `fetcher`.
         if dataset.lang_julia_fetcher != ""
             _run_julia_ref(db, dataset, download_path, project_root;
                           required_paths_ordered=required_paths_ordered)
             return
         end
-        shell_fetcher = _lang_shell_fetcher(dataset)
-        if shell_fetcher != ""
-            _run_shell(shell_fetcher, dataset, download_path, project_root;
+        bare_fetcher = _bare_fetcher_ref(dataset)
+        if bare_fetcher != "" &&
+           _run_bare_fetcher(db, dataset, bare_fetcher, download_path, project_root;
+                            required_paths_ordered=required_paths_ordered)
+            return
+        end
+        # rung 2 — the dataset's `shell` command (bare field, else legacy `_LANG.shell`).
+        shell_cmd = _shell_command(dataset)
+        if shell_cmd != ""
+            _run_shell(shell_cmd, dataset, download_path, project_root;
                       required_paths_by_ref=required_paths_by_ref,
                       required_paths_ordered=required_paths_ordered)
             return
         end
         if isempty(dataset.uris) && dataset.uri == ""
-            error("No fetcher resolved for dataset \"$(dataset.key)\": no own " *
-                  "`_LANG.julia.fetcher`, no `_LANG.shell.fetcher`, and no `uri`/`uris`.")
+            error("No fetcher resolved for dataset \"$(dataset.key)\": no own/bare " *
+                  "`fetcher`, no `shell` command, and no `uri`/`uris`.")
         end
     end
 
@@ -630,7 +680,8 @@ function download_dataset(db::Database, dataset::DatasetEntry; extract::Union{No
     # shell fetcher, no `uri`, but a foreign-language fetcher exists. Delegate to the peer
     # `datamanifest` CLI, which materializes the result in the shared store; we then read it.
     if db.schema == 1 && (overwrite || !(isfile(download_path) || isdir(download_path))) &&
-       dataset.lang_julia_fetcher == "" && _lang_shell_fetcher(dataset) == "" &&
+       dataset.lang_julia_fetcher == "" && _bare_fetcher_ref(dataset) == "" &&
+       _shell_command(dataset) == "" &&
        isempty(dataset.uris) && dataset.uri == "" &&
        _should_delegate(dataset) && !isempty(_foreign_fetcher_langs(dataset))
         if _delegate_fetch(db, name)
@@ -731,47 +782,69 @@ function default_loader(db::Database, format::AbstractString)
     return builtin_default_loader(format)
 end
 
-# v1 load ladder: own `_LANG.julia.loader` ref → manifest
-# `[_LANG.julia.loaders][format]` ref → built-in format default → error. Every
-# rung resolves by import + getfield or a built-in lookup; a v1 loader never
-# spawns a subprocess and never goes through `include_string`. (Delegation — a
-# foreign-language loader — is out of scope.)
+# Resolve a loader binding (string or `{ ref, args, kwargs }` table) to a `path -> value`
+# function: the conventional call `fn(path)` for a ref-only binding, or a parameterized call
+# `ref(args...; kwargs...)` (with `$var`/`$path` substitution) when args/kwargs are present.
+function _loader_from_binding(db::Database, entry::DatasetEntry, b)
+    ref, args, kwargs = _parse_binding(b)
+    isempty(ref) && error("loader binding has no `ref`.")
+    fn = _resolve_ref(db, ref)
+    (isempty(args) && isempty(kwargs)) && return fn
+    return function (path)
+        subs = _binding_subst_pairs(entry, "\$path" => path, get_project_root(db))
+        a = _subst_binding_value(args, subs)
+        kw = _kwargs_pairs(_subst_binding_value(kwargs, subs))
+        return Base.invokelatest(fn, a...; kw...)
+    end
+end
+
+# v1 load ladder (spec-v3.4):
+#   1. own `[<ds>._LANG.julia].loader`, else the bare (language-implicit) `loader`;
+#   2. `[_LANG.julia.loaders][format]`, else `[_LOADERS][format]` (language-implicit);
+#   3. built-in format default; else error.
+# At each own-language rung the explicit `_LANG.julia` binding wins over the bare one; a bare
+# binding that fails to resolve in Julia warns and falls through (tolerant, never a hard
+# error on that account). A v1 loader never spawns a subprocess / never `include_string`s.
 function _resolve_loader_v1(db::Database, entry::DatasetEntry)
+    # rung 1 — explicit own loader, else the bare language-implicit loader.
     if entry.lang_julia_loader != ""
-        return _resolve_ref(db, entry.lang_julia_loader)
+        return _loader_from_binding(db, entry, entry.lang_julia_loader)
+    end
+    if entry.loader != ""
+        try
+            return _loader_from_binding(db, entry, entry.loader)
+        catch e
+            @warn "Bare `loader` did not resolve in Julia; falling through to format defaults" ref = entry.loader exception = e
+        end
     end
     # For extracted archives, path is a directory; no single-file format to load.
     format = (entry.extract && entry.format in COMPRESSED_FORMATS) ? "" : entry.format
     fmt = lowercase(strip(format))
     if !isempty(fmt)
+        # rung 2 — `[_LANG.julia.loaders][fmt]`, else `[_LOADERS][fmt]` (language-implicit).
         for (k, b) in pairs(db.lang_julia_loaders)
+            lowercase(strip(k)) == fmt && return _loader_from_binding(db, entry, b)
+        end
+        for (k, b) in pairs(db.loaders)
             if lowercase(strip(k)) == fmt
-                # spec-v3.3: a project loader is a binding (string or `{ ref, args, kwargs }`).
-                ref, args, kwargs = _parse_binding(b)
-                isempty(ref) && error("Project loader for format \"$fmt\" has no `ref`.")
-                fn = _resolve_ref(db, ref)
-                if isempty(args) && isempty(kwargs)
-                    return fn   # ref-only: conventional call fn(path)
-                end
-                # Parameterized: substitute `$var` (incl. `$path`) and call ref(args...; kwargs...).
-                return function (path)
-                    subs = _binding_subst_pairs(entry, "\$path" => path, get_project_root(db))
-                    a = _subst_binding_value(args, subs)
-                    kw = _kwargs_pairs(_subst_binding_value(kwargs, subs))
-                    return Base.invokelatest(fn, a...; kw...)
+                try
+                    return _loader_from_binding(db, entry, b)
+                catch e
+                    @warn "Bare `[_LOADERS]` loader did not resolve in Julia; falling through" format = fmt exception = e
                 end
             end
         end
     end
+    # rung 3 — built-in format default.
     if isempty(fmt)
-        error("No loader resolved for dataset \"$(entry.key)\": no own " *
-              "`_LANG.julia.loader`, no `[_LANG.julia.loaders]` entry, and the dataset format is empty.")
+        error("No loader resolved for dataset \"$(entry.key)\": no own/bare `loader`, no " *
+              "`[_LANG.julia.loaders]`/`[_LOADERS]` entry, and the dataset format is empty.")
     end
     try
         return builtin_default_loader(format)
     catch
-        error("No loader resolved for dataset \"$(entry.key)\" (format \"$format\"): no own " *
-              "`_LANG.julia.loader`, no `[_LANG.julia.loaders][$fmt]`, and no built-in loader for \"$format\".")
+        error("No loader resolved for dataset \"$(entry.key)\" (format \"$format\"): no own/bare " *
+              "`loader`, no `[_LANG.julia.loaders][$fmt]`/`[_LOADERS][$fmt]`, and no built-in loader.")
     end
 end
 

--- a/test/conformance_pin.toml
+++ b/test/conformance_pin.toml
@@ -3,18 +3,20 @@
 # The tag + per-file content hashes below are this tool's machine-checkable
 # conformance claim. Hashes are computed from fixture file contents (not the
 # tarball bytes) so the pin stays correct if GitHub re-packs the auto-archive.
-spec_tag = "spec-v3.3"
+spec_tag = "spec-v3.5"
 
 [files]
-"tests/fixtures/README.md" = "487a6f15bc978f4b0e1695409f9292ed2c867d1518f4d0ec3510a4d6af6136a0"
+"tests/fixtures/README.md" = "0957890490e2850073bb37ab785666329bbfab7a09fa42ed561af69fea06d679"
 "tests/fixtures/cached_index.expected.json" = "2f8ab1ffe68f0e15d5f444568c283cf58eb0456d51f2974155a2dda4ae3548ac"
 "tests/fixtures/cached_index.toml" = "4fb123b0da25e60e6bad9e47ef079639e3899cac006f17d98002f4ba8b7d4da8"
 "tests/fixtures/config_sidecar.expected.json" = "3f3f34e31df88a44f7bd8b598fba93432b286109c7a1bea31953850aca7cbb0b"
 "tests/fixtures/config_sidecar.toml" = "46df73bb0bf0449018107729b9ea2587bc8d1931be1250f076b490eedc5bed98"
 "tests/fixtures/config_sidecar_float.expected.json" = "c47d76f5f3d66379ac5d1ef8718de008f7aff52e56fff6336174035521dd923a"
 "tests/fixtures/config_sidecar_float.toml" = "ceada3c4baf50cb5c97299f2e1cbe84808a8366f9434dda0d99a4f49b9455bd0"
-"tests/fixtures/multilang.expected.json" = "e9227a25d704e84da11d18287bda8397dedecef6412d10534b919924dfb6cb43"
-"tests/fixtures/multilang.toml" = "60793653a61563c23dced82da81e6d2b69ae887f84abae659d5a0ab5df6c3014"
+"tests/fixtures/lang_implicit.expected.json" = "ea0f367fbeb62fa8cca0f7f2c8543f51409e81533d6fb33bb7bef8b816d61105"
+"tests/fixtures/lang_implicit.toml" = "99b7b62ad67a13558a1ff9bcb0fd4c73b702155f8976147f8b552969ac115936"
+"tests/fixtures/multilang.expected.json" = "77564105d84a5f5d488fc47603cf8401e14acbf18a21727f7115ed4968de5022"
+"tests/fixtures/multilang.toml" = "1d6d7c98bbd733b06b89002db809831c5f68bcf8786d43d60322766e9a3af310"
 "tests/fixtures/parameterized.expected.json" = "7c21ba2374778676c6dfd1ed3d4195380a3c041867a5b218f68edf25e5aa2fa5"
 "tests/fixtures/parameterized.toml" = "124587678d51e41fa224f642dd7f97aa11a5b15b8dc1c078b45c4986cfa2c287"
 "tests/fixtures/single_julia.expected.json" = "ca32e4171da18bcf03df7892deed73ed3ad088fd3da9076f76cd44cbfeccff3c"

--- a/test/conformance_pin.toml
+++ b/test/conformance_pin.toml
@@ -3,7 +3,7 @@
 # The tag + per-file content hashes below are this tool's machine-checkable
 # conformance claim. Hashes are computed from fixture file contents (not the
 # tarball bytes) so the pin stays correct if GitHub re-packs the auto-archive.
-spec_tag = "spec-v3.2"
+spec_tag = "spec-v3.3"
 
 [files]
 "tests/fixtures/README.md" = "487a6f15bc978f4b0e1695409f9292ed2c867d1518f4d0ec3510a4d6af6136a0"

--- a/test/conformance_pin.toml
+++ b/test/conformance_pin.toml
@@ -3,7 +3,7 @@
 # The tag + per-file content hashes below are this tool's machine-checkable
 # conformance claim. Hashes are computed from fixture file contents (not the
 # tarball bytes) so the pin stays correct if GitHub re-packs the auto-archive.
-spec_tag = "spec-v3.5"
+spec_tag = "spec-v3.6"
 
 [files]
 "tests/fixtures/README.md" = "0957890490e2850073bb37ab785666329bbfab7a09fa42ed561af69fea06d679"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1030,6 +1030,11 @@ try
         @test P._bare_fetcher_ref(DB.DatasetEntry(; extra=Dict{String,Any}("fetcher" => "M:f"))) == "M:f"
         @test P._bare_fetcher_ref(DB.DatasetEntry(; extra=Dict{String,Any}(
             "fetcher" => Dict{String,Any}("ref" => "M:f")))) == "M:f"
+
+        # spec-v3.6: a present bare loader that does not resolve is an ERROR — it MUST NOT
+        # fall through to the built-in csv loader (which would otherwise succeed here).
+        e_bad = DB.DatasetEntry(; format="csv", loader="NoSuchModule12345abc:nope")
+        @test_throws Exception P._resolve_loader_v1(DB.Database(persist=false), e_bad)
     end
 
     @testset "spec-v3.5 bare shell fetch (end-to-end)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -943,6 +943,64 @@ try
         @test !isdir(survivor.location)
         @test newloc == joinpath(dest, survivor.cachetype, survivor.hash)
     end
+
+    @testset "spec-v3.3 bindings + delegation (rung 3)" begin
+        DB = DataManifest.Databases
+        P  = DataManifest.PipeLines
+
+        # --- Project-wide loaders accept string|table; ref-only writes as a string ---
+        mktempdir() do d
+            toml = joinpath(d, "datasets.toml")
+            write(toml, """
+            [_META]
+            schema = 1
+
+            [_LANG.julia.loaders]
+            nc  = "NCDatasets:Dataset"
+            csv = { ref = "CSV:read" }
+            grid = { ref = "MyPkg:load", kwargs = { res = "5x5" } }
+
+            [ds]
+            uri = "https://example.com/x.nc"
+            format = "nc"
+            """)
+            db = read_dataset(toml, d; persist=false)
+            @test db.lang_julia_loaders["nc"] == "NCDatasets:Dataset"
+            @test db.lang_julia_loaders["csv"] isa AbstractDict     # raw binding kept
+            @test db.lang_julia_loaders["grid"]["kwargs"]["res"] == "5x5"
+
+            out = joinpath(d, "out.toml")
+            write(db, out)
+            txt = read(out, String)
+            @test occursin("nc = \"NCDatasets:Dataset\"", txt)
+            @test occursin("csv = \"CSV:read\"", txt)         # ref-only → bare string
+            @test occursin("ref = \"MyPkg:load\"", txt)       # parameterized → table
+            # Round-trips back identically.
+            db2 = read_dataset(out, d; persist=false)
+            @test db2.lang_julia_loaders["csv"] == "CSV:read"  # normalized on write
+            @test db2.lang_julia_loaders["grid"]["kwargs"]["res"] == "5x5"
+        end
+
+        # --- Delegation (rung 3) gating helpers ---
+        # A foreign (python) fetcher with no julia/shell fetcher and no uri is delegated.
+        e = DB.DatasetEntry(; extra=Dict{String,Any}(
+            "_LANG" => Dict{String,Any}("python" => Dict{String,Any}("fetcher" => "m:f"))))
+        @test P._foreign_fetcher_langs(e) == ["python"]
+        @test P._should_delegate(e) == true
+        # `delegate = false` disables it.
+        e_off = DB.DatasetEntry(; extra=Dict{String,Any}(
+            "delegate" => false,
+            "_LANG" => Dict{String,Any}("python" => Dict{String,Any}("fetcher" => "m:f"))))
+        @test P._should_delegate(e_off) == false
+        # julia/shell fetchers are not "foreign"; a uri-only dataset has none.
+        e_shell = DB.DatasetEntry(; extra=Dict{String,Any}(
+            "_LANG" => Dict{String,Any}("shell" => Dict{String,Any}("fetcher" => "make x"))))
+        @test isempty(P._foreign_fetcher_langs(e_shell))
+        @test isempty(P._foreign_fetcher_langs(DB.DatasetEntry(; uri="https://x/y.nc")))
+        # _delegate_fetch is a no-op (false) when there is no manifest on disk.
+        db_mem = DB.Database(persist=false)
+        @test P._delegate_fetch(db_mem, "ds") == false
+    end
 end
 
 @testset "Conformance suite (spec-v3.x)" begin
@@ -1003,10 +1061,11 @@ end
             # Capabilities this tool implements; drives which fixtures are run.
             # `cache-produce` = the @cached produce-or-load layer (DataManifest.Cache).
             # `inspect` = the cached.toml index + store-maintenance surface (Phase 2).
+            # `delegation` = cross-language fetch rung 3 via the peer `datamanifest` CLI.
             # `sync` (cross-machine push/pull) is not yet implemented.
             SUPPORTED_CAPABILITIES = Set(["lang-read", "lang-write", "shell-fetch",
                                           "storage", "binding-args", "byte-identity",
-                                          "cache-produce", "inspect"])
+                                          "cache-produce", "inspect", "delegation"])
 
             toml_fnames = sort(filter(f -> endswith(f, ".toml"), readdir(fixtures_top)))
             for toml_fname in toml_fnames

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,13 @@ end
 
 # ----- conformance helpers (used by the conformance testset below) -----
 
+# A binding's ref: the bare string, or a `{ ref … }` table's `ref` ("" otherwise).
+_conf_binding_ref(b) = b isa AbstractString ? String(b) :
+    (b isa AbstractDict && get(b, "ref", "") isa AbstractString ? String(get(b, "ref", "")) : "")
+
+# spec-v3.5: the dataset's shell command — bare `shell` field, else legacy `[_LANG.shell].fetcher`.
 function _conf_shell_fetcher(entry::DatasetEntry)::String
+    entry.shell != "" && return entry.shell
     lang = get(entry.extra, "_LANG", nothing)
     lang isa AbstractDict || return ""
     shell = get(lang, "shell", nothing)
@@ -26,8 +32,14 @@ function _conf_shell_fetcher(entry::DatasetEntry)::String
     f isa AbstractString ? String(f) : ""
 end
 
+# spec-v3.4: the bare (language-implicit) fetcher ref, or "".
+_conf_bare_fetcher(entry::DatasetEntry)::String = _conf_binding_ref(get(entry.extra, "fetcher", nothing))
+
 function _conf_infer_fetcher(db::Database, entry::DatasetEntry)
+    # rung 1: explicit own fetcher, else bare (language-implicit) fetcher.
     entry.lang_julia_fetcher != "" && return ("own-fetcher", entry.lang_julia_fetcher)
+    bf = _conf_bare_fetcher(entry)
+    bf != "" && return ("own-fetcher", bf)
     sf = _conf_shell_fetcher(entry)
     sf != "" && return ("shell", sf)
     (entry.uri != "" || !isempty(entry.uris)) && return ("uri", nothing)
@@ -35,11 +47,17 @@ function _conf_infer_fetcher(db::Database, entry::DatasetEntry)
 end
 
 function _conf_infer_loader(db::Database, entry::DatasetEntry)
+    # rung 1: explicit own loader, else bare (language-implicit) loader.
     entry.lang_julia_loader != "" && return ("per-dataset", entry.lang_julia_loader)
+    entry.loader != "" && return ("per-dataset", entry.loader)
     fmt = lowercase(strip(entry.format))
     if !isempty(fmt)
-        for (k, ref) in pairs(db.lang_julia_loaders)
-            lowercase(strip(k)) == fmt && return ("manifest-format-default", ref)
+        # rung 2: `[_LANG.julia.loaders][fmt]`, else `[_LOADERS][fmt]` (language-implicit).
+        for (k, b) in pairs(db.lang_julia_loaders)
+            lowercase(strip(k)) == fmt && return ("manifest-format-default", _conf_binding_ref(b))
+        end
+        for (k, b) in pairs(db.loaders)
+            lowercase(strip(k)) == fmt && return ("manifest-format-default", _conf_binding_ref(b))
         end
     end
     return ("builtin", nothing)
@@ -1000,6 +1018,40 @@ try
         # _delegate_fetch is a no-op (false) when there is no manifest on disk.
         db_mem = DB.Database(persist=false)
         @test P._delegate_fetch(db_mem, "ds") == false
+
+        # spec-v3.5: the dataset's shell command is the bare `shell` field (preferred over
+        # the legacy [_LANG.shell].fetcher).
+        e_bare = DB.DatasetEntry(; shell="make x")
+        @test P._shell_command(e_bare) == "make x"
+        e_legacy = DB.DatasetEntry(; extra=Dict{String,Any}(
+            "_LANG" => Dict{String,Any}("shell" => Dict{String,Any}("fetcher" => "old"))))
+        @test P._shell_command(e_legacy) == "old"
+        # spec-v3.4: bare fetcher ref (string + table form).
+        @test P._bare_fetcher_ref(DB.DatasetEntry(; extra=Dict{String,Any}("fetcher" => "M:f"))) == "M:f"
+        @test P._bare_fetcher_ref(DB.DatasetEntry(; extra=Dict{String,Any}(
+            "fetcher" => Dict{String,Any}("ref" => "M:f")))) == "M:f"
+    end
+
+    @testset "spec-v3.5 bare shell fetch (end-to-end)" begin
+        # A v1 dataset with a bare `shell` command and no uri is produced via fetch ladder
+        # rung 2 (bare shell), then resolves on disk — no _LANG.shell wrapper needed.
+        mktempdir() do d
+            src = joinpath(d, "src.txt"); write(src, "from-bare-shell")
+            toml = joinpath(d, "datasets.toml")
+            write(toml, """
+            [_META]
+            schema = 1
+
+            [made]
+            format = "txt"
+            key    = "made"
+            shell  = "cp $src \$download_path"
+            """)
+            db = read_dataset(toml, joinpath(d, "store"); persist=false)
+            path = download_dataset(db, "made")
+            @test isfile(path)
+            @test strip(read(path, String)) == "from-bare-shell"
+        end
     end
 end
 


### PR DESCRIPTION
Builds on #5 (v0.19.0). Targets **spec-v3.3**; only `sync` now remains unimplemented.

## Cross-language fetch — capability `delegation`
Fetch-ladder rung 3: a dataset whose bytes can be produced only by a foreign-language fetcher (no own `_LANG.julia.fetcher`, no `_LANG.shell.fetcher`, no `uri`, but e.g. `[<ds>._LANG.python].fetcher`) is delegated to the Python `datamanifest` CLI when on `PATH` — `datamanifest download <name>` with `DATAMANIFEST_TOML` set; the peer materializes the result in the shared store (verifying `sha256`) and we read it back. Falls through to `uri` when the peer is absent, fails, or `delegate = false`. Native/shell datasets never reach this rung.

## spec-v3.3 binding harmonization (string|table everywhere)
- Project-wide `[_LANG.julia.loaders]` values may now be a `{ ref, args, kwargs }` table (parameterized format-default loader), not only a string. `lang_julia_loaders` widened to `Dict{String,Any}`; parameterized resolution added to the load ladder.
- Canonical write: a ref-only binding (`{ ref = "M:f" }`) normalizes to the bare string; parameterized stays a table. (Per-dataset bindings already did this; project loaders now too.)

## Conformance / docs
- Pinned to **spec-v3.3**, declares `delegation`. **229 unit + 194 conformance** tests pass.
- README aligned with the spec's annotated [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml) (linked; binding snippets drawn from it).

## Deferred
**spec-v3.4** (language-implicit bare `fetcher`/`loader` bindings + `[_LOADERS]` as the bare format-default map) is intentionally **not** in this PR: its conformance fixtures are not yet published. Its rules (explicit-wins precedence, tolerant warn-and-fall-through, verbatim round-trip) are exactly what those fixtures validate, so it follows once they land.