### PR TITLE
Add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Cache mkdocs-material assets
+        uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ github.sha }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ file; `DataManifest.jl` downloads, verifies, extracts and loads them, and caches
 your own computed results with the same machinery. It supports data repositories
 such as PANGAEA or Zenodo and git hosts such as GitHub. The manifest format is
 [shared across languages](https://github.com/perrette/datamanifest.toml) — the
-[Python implementation](https://github.com/perrette/datamanifest) reads the same
-file, and brings a full command-line interface on top.
+[reference Python implementation](https://github.com/perrette/datamanifest) reads the
+same file, and brings a full command-line interface on top.
 
 <!-- intro-start -->
 - **Declare once, fetch anywhere.** Data dependencies — URLs, git repos,
@@ -107,7 +107,7 @@ register and fetch a dataset; the rest is there when a project needs it.
 **The DataManifest family (one manifest, many languages):**
 
 - [`perrette/datamanifest.toml`](https://github.com/perrette/datamanifest.toml) — the shared TOML schema spec; the common contract every implementation reads.
-- [`perrette/datamanifest`](https://github.com/perrette/datamanifest) — the Python implementation, sharing the same `Datasets.toml` via the `_LANG` namespace; also the home of the CLI.
+- [`perrette/datamanifest`](https://github.com/perrette/datamanifest) — the **reference** Python implementation, sharing the same `Datasets.toml` via the `_LANG` namespace; also the home of the CLI.
 
 **Julia alternatives** (single-language). As a rule of thumb: if you only need code-driven download-and-checksum, DataDeps.jl is lighter; if you want a rich declarative data ecosystem, DataToolkit.jl is richer; DataManifest.jl targets multi-dataset, multi-language scientific projects that want the whole dependency declaration — and its derived-data cache — in one shareable file.
 

--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ rather than code embedded in the config file.
 
 ## From the same author
 
-A few related tools I maintain, useful in a Markdown-based scientific workflow.
+A few other open-source tools I maintain.
 
 **Scientific writing & data**
 
 - [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and convert them to journal-ready LaTeX/PDF.
 - [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
-- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
+- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec.)*
 
-**Voice helpers** — handy for dictating and proofreading drafts by ear
+**Speech to Text (dictate) and Text to Speech (read-aloud) tools**
 
-- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation (Whisper).
-- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader (Kokoro / Piper).
+- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation.
+- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader.

--- a/README.md
+++ b/README.md
@@ -116,3 +116,18 @@ register and fetch a dataset; the rest is there when a project needs it.
 - [`DrWatson.jl`](https://juliadynamics.github.io/DrWatson.jl/dev/) — broader scientific-project organization (simulations, file layout, naming), of which data handling is one part.
 - [`RemoteFiles.jl`](https://github.com/helgee/RemoteFiles.jl) — keep a local file in sync with a remote URL.
 - Pkg Artifacts (`Artifacts.toml`) — Julia's built-in TOML manifest of content-addressed, hash-pinned data/binary bundles tied to packages.
+
+## From the same author
+
+A small toolkit for a Markdown-first scientific workflow.
+
+**Scientific writing & data**
+
+- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and submit them to any journal (Markdown → LaTeX/PDF).
+- [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
+- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
+
+**Voice helpers** — handy for dictating and proofreading drafts by ear
+
+- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation (Whisper).
+- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader (Kokoro / Piper).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/perrette/datamanifest.toml/main/design/logo/lockup-dark.svg">
-    <img src="https://raw.githubusercontent.com/perrette/datamanifest.toml/main/design/logo/lockup.svg" alt="datamanifest.toml" height="76">
+    <img src="https://raw.githubusercontent.com/perrette/datamanifest.toml/main/design/logo/lockup.svg" alt="DataManifest.jl" height="76">
   </picture>
 </p>
 
 # DataManifest.jl
 
 [![CI](https://github.com/awi-esc/DataManifest.jl/actions/workflows/ci.yaml/badge.svg)](https://github.com/awi-esc/DataManifest.jl/actions/workflows/ci.yaml)
+[![docs](https://img.shields.io/badge/docs-awi--esc.github.io%2FDataManifest.jl-blue)](https://awi-esc.github.io/DataManifest.jl/)
 
 Keep track of the datasets used in a scientific project. You declare your data
 dependencies — URLs, git repositories, checksums, formats — in a `Datasets.toml`
@@ -16,8 +17,27 @@ your own computed results with the same machinery. It supports data repositories
 such as PANGAEA or Zenodo and git hosts such as GitHub. The manifest format is
 [shared across languages](https://github.com/perrette/datamanifest.toml) — the
 [Python implementation](https://github.com/perrette/datamanifest) reads the same
-file, and brings a [full command-line interface](#manage-your-data-from-the-shell)
-on top.
+file, and brings a full command-line interface on top.
+
+<!-- intro-start -->
+- **Declare once, fetch anywhere.** Data dependencies — URLs, git repos,
+  checksums, formats — live in a plain `Datasets.toml` you commit; a
+  collaborator runs `download_datasets()` to materialize everything, verified
+  by SHA-256.
+- **One manifest, several languages.** The TOML schema is shared across
+  implementations, so the same file is read by sibling tools in other languages
+  via a `_LANG` namespace — a Julia and a Python project can share one data
+  declaration without stepping on each other.
+- **Produce-or-load caching.** The `@cached` layer caches the result of an
+  expensive computation on disk, keyed by its parameters — reproducible across
+  tools, with the same storage machinery as fetched data.
+- **Put data where you want it.** Repo-local by default, or point a folder at a
+  shared location with `$`-symbols and per-host overrides; read pools reuse data
+  another project already fetched.
+- **Declarative, no lock-in.** Custom fetch/load logic is a *reference* to
+  external code (`Module:function`), not code embedded in the config; the
+  manifest stays a plain, hand-editable TOML file.
+<!-- intro-end -->
 
 `DataManifest.jl` is still actively developed, with breaking changes until
 v1.0.0 is reached.
@@ -29,15 +49,12 @@ using Pkg
 Pkg.add("DataManifest")
 ```
 
-Bleeding edge:
-
-```julia
-Pkg.add(url="https://github.com/awi-esc/DataManifest.jl")
-```
+See the [installation page](https://awi-esc.github.io/DataManifest.jl/installation/)
+for optional format loaders and the Python CLI sibling.
 
 ## Quick start
 
-In an activated project (`using Pkg; Pkg.activate(...)`):
+In an activated project:
 
 ```julia
 using DataManifest
@@ -46,149 +63,24 @@ DataManifest.add("https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.c
 path = get_dataset_path("co2")   # resolves under datasets_dir, by default ./datasets/<key>
 ```
 
-The `add` downloaded the Mauna Loa CO₂ record and wrote one entry to
-`Datasets.toml` next to your `Project.toml` — a plain TOML file you can read and
-edit by hand, byte-identical to what the sibling Python tool writes:
-
-```toml
-[co2]
-sha256 = "0058b3788040b5c27b2b5c1dd6d26226b7e4deef85e34c153e64806c37df7c75"
-uri = "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"
-```
-
-**Commit `Datasets.toml`** — it's the recipe (what to fetch and how). The
-downloaded data and a local `.datamanifest-state.toml` (which records *where*
-each file landed on this machine) stay git-ignored. A collaborator runs
-`download_datasets()` to materialize everything.
-
-To be explicit instead of relying on the activated project:
-
-```julia
-db = Database("Datasets.toml", "my-data-folder")
-DataManifest.add(db, "https://…"; name="…")
-path = get_dataset_path(db, "co2")
-```
-
-For library code that wants checksummed downloads into a folder it controls —
-an OS-appropriate data dir, say — a **file-less database** skips the manifest
-entirely: no `Datasets.toml`, no state file, nothing written but the data. The
-folder accepts the same `$`-symbols as the storage model, e.g. `$user_data_dir`
-or `$user_cache_dir` (`raw"…"` keeps Julia from interpolating the `$`):
-
-```julia
-db = Database(datasets_folder=raw"$user_data_dir/mylib", persist=false)
-DataManifest.add(db, "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"; name="co2")
-path = get_dataset_path(db, "co2")   # → ~/.local/share/mylib/gml.noaa.gov/…/co2_annmean_mlo.csv
-```
-
-With a loader declared for the dataset (or its format), `load_dataset("co2")`
-returns the loaded object directly — see
-[per-language bindings](docs/language-bindings.md).
-
-## Produce-or-load caching (`@cached`)
-
-Cache the result of an expensive computation, keyed by its parameters:
-
-```julia
-using DataManifest
-
-@cached key=(a -> (; a.grid)) function load_anomaly(; grid::String = "5x5")
-    # … expensive computation …
-    return result
-end
-
-load_anomaly(; grid="5x5")               # computes once, then loads from disk on repeat calls
-load_anomaly(; grid="5x5", cached=false) # escape hatch: run the body, no disk I/O
-```
-
-Each distinct parameter combination is stored separately under `./cached/` by
-default, self-describing and reproducible across tools. Serialization is the
-zero-dependency `jls` built-in; register others (`nc`, `jld2`, …) with
-`DataManifest.Cache.register_format!`, and pass `version=` to deliberately bust
-the cache. Full behaviour — the cache key, artifact layout, `cachetype`
-identity: [docs/caching.md](docs/caching.md).
-
-## Manage your data from the shell
-
-DataManifest.jl ships no CLI of its own — it doesn't need one. The manifest is
-language-neutral, and the Python implementation's **`datamanifest`** CLI manages
-the same file (it auto-detects `Datasets.toml`): everything around the data —
-adding, listing, verifying, repairing, syncing — works from the shell, without
-touching your Julia code.
-
-```bash
-pip install datamanifestpy
-```
-
-```bash
-datamanifest list                 # what's tracked, and where it lives
-datamanifest add https://host/path/file.nc
-datamanifest verify               # re-check every checksum
-datamanifest refresh --scan       # repair: reassociate data found on disk
-datamanifest push co2 user@hpc    # rsync a dataset to another machine
-datamanifest storage              # where data goes on this host
-```
-
-See the [Python README](https://github.com/perrette/datamanifest#readme) for
-the use cases and the [CLI reference](https://github.com/perrette/datamanifest/blob/main/docs/cli.md)
-for every command. The two tools also cooperate at fetch time: a dataset whose
-fetcher is written in Python is materialized by delegating to this same CLI
-(and the Python tool can delegate to Julia in turn) — see
-[cross-language fetch](docs/language-bindings.md#the-ladders).
-
-## One manifest, several languages
-
-A dataset can carry per-language `fetcher`/`loader` bindings under `_LANG` —
-`Module:function` references, never inline code. Each implementation runs its
-own and preserves the others verbatim, so one manifest serves a mixed
-Julia/Python project:
-
-```toml
-[_LANG.julia.loaders]            # project-wide format → loader defaults
-csv = "CSV:read"
-nc  = "NCDatasets:Dataset"
-
-[ocean_temp]
-uri = "https://example.com/ocean_temp.nc"
-format = "nc"
-
-[ocean_temp._LANG.julia]
-loader = "MyClimate:load_argo"   # per-dataset override
-
-[ocean_temp._LANG.python]
-loader = "myclimate.load:argo"   # Python's binding; Julia never touches it
-```
-
-A single-language project can skip the `_LANG` ceremony with bare
-`fetcher` / `loader` / `shell` fields. Resolution ladders, parameterized
-bindings (`{ ref, args, kwargs }`), lazy access to object stores
-(`lazy_access`), and cross-language fetch:
-[docs/language-bindings.md](docs/language-bindings.md).
-
-## Put data where you want it
-
-Storage is two folders set in `[_STORAGE]` — `datasets_dir` (fetched data) and
-`datacache_dir` (`@cached` results) — repo-local `./datasets/` and `./cached/`
-by default, with `$`-symbols and per-host overrides for anything else:
-
-```toml
-[_STORAGE]
-datasets_dir = "$user_data_dir/myproj"   # share across clones / projects
-
-[_STORAGE._HOST."login*.hpc.edu"]
-datasets_dir = "/scratch/$USER/data"     # host-specific override
-```
-
-Path expressions, the resolution ladder, per-dataset overrides, read pools
-(reuse data another project already fetched), and the state file that makes
-moved data recoverable: [docs/storage.md](docs/storage.md).
+This downloads the dataset and writes one entry to `Datasets.toml` next to your
+`Project.toml`. **Commit `Datasets.toml`** — it's the recipe; the downloaded
+data and the local `.datamanifest-state.toml` stay git-ignored. See the
+[quick start](https://awi-esc.github.io/DataManifest.jl/quickstart/) for the
+file-less database and more.
 
 ## Documentation
 
-- [docs/doc.md](docs/doc.md) — the long-form walkthrough; [docs/api.md](docs/api.md) — the API.
-- [docs/language-bindings.md](docs/language-bindings.md) — `_LANG`, ladders, `lazy_access`, migration.
-- [docs/storage.md](docs/storage.md) — storage model, read pools, state file, maintenance.
-- [docs/caching.md](docs/caching.md) — the `@cached` layer in full.
+Full documentation lives at **<https://awi-esc.github.io/DataManifest.jl/>**:
+
+- [Installation](https://awi-esc.github.io/DataManifest.jl/installation/)
+- [Quick start](https://awi-esc.github.io/DataManifest.jl/quickstart/)
+- [Walkthrough](https://awi-esc.github.io/DataManifest.jl/doc/) — every feature, end to end
+- [Produce-or-load caching (`@cached`)](https://awi-esc.github.io/DataManifest.jl/caching/)
+- [Per-language bindings](https://awi-esc.github.io/DataManifest.jl/language-bindings/) — `_LANG`, ladders, `lazy_access`
+- [Storage model](https://awi-esc.github.io/DataManifest.jl/storage/) — read pools, state file, maintenance
+- [Manage your data from the shell](https://awi-esc.github.io/DataManifest.jl/shell/) — the Python CLI
+- [API reference](https://awi-esc.github.io/DataManifest.jl/api/)
 
 ## Conformance
 
@@ -200,11 +92,6 @@ Implemented capabilities: `lang-read`, `lang-write`, `shell-fetch`, `storage`,
 `binding-args`, `byte-identity`, `cache-produce`, `inspect`, `delegation`; only
 `sync` (cross-machine `push`/`pull`) is not yet implemented — use the Python CLI
 for that.
-
-## Roadmap
-
-Nothing at this point. After some time of usage and feedbacks, the roadmap will
-be updated, and eventually I'll make the v1.0.0 release.
 
 ## Related projects
 
@@ -220,7 +107,7 @@ register and fetch a dataset; the rest is there when a project needs it.
 **The DataManifest family (one manifest, many languages):**
 
 - [`perrette/datamanifest.toml`](https://github.com/perrette/datamanifest.toml) — the shared TOML schema spec; the common contract every implementation reads.
-- [`perrette/datamanifest`](https://github.com/perrette/datamanifest) — the Python implementation, sharing the same `Datasets.toml` via the `_LANG` namespace; also the home of the [CLI](#manage-your-data-from-the-shell).
+- [`perrette/datamanifest`](https://github.com/perrette/datamanifest) — the Python implementation, sharing the same `Datasets.toml` via the `_LANG` namespace; also the home of the CLI.
 
 **Julia alternatives** (single-language). As a rule of thumb: if you only need code-driven download-and-checksum, DataDeps.jl is lighter; if you want a rich declarative data ecosystem, DataToolkit.jl is richer; DataManifest.jl targets multi-dataset, multi-language scientific projects that want the whole dependency declaration — and its derived-data cache — in one shareable file.
 

--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ such as PANGAEA or Zenodo and git hosts such as GitHub. The manifest format is
 same file, and brings a full command-line interface on top.
 
 <!-- intro-start -->
-- **Declare once, fetch anywhere.** Data dependencies — URLs, git repos,
+- **Declare dependencies in a file.** Data dependencies — URLs, git repos,
   checksums, formats — live in a plain `Datasets.toml` you commit; a
   collaborator runs `download_datasets()` to materialize everything, verified
   by SHA-256.
-- **One manifest, several languages.** The TOML schema is shared across
+- **Shared schema across languages.** The TOML schema is shared across
   implementations, so the same file is read by sibling tools in other languages
   via a `_LANG` namespace — a Julia and a Python project can share one data
   declaration without stepping on each other.
 - **Produce-or-load caching.** The `@cached` layer caches the result of an
   expensive computation on disk, keyed by its parameters — reproducible across
   tools, with the same storage machinery as fetched data.
-- **Put data where you want it.** Repo-local by default, or point a folder at a
+- **Configurable storage layout.** Repo-local by default, or point a folder at a
   shared location with `$`-symbols and per-host overrides; read pools reuse data
   another project already fetched.
-- **Declarative, no lock-in.** Custom fetch/load logic is a *reference* to
+- **Declarative configuration.** Custom fetch/load logic is a *reference* to
   external code (`Module:function`), not code embedded in the config; the
   manifest stays a plain, hand-editable TOML file.
 <!-- intro-end -->
@@ -95,14 +95,13 @@ for that.
 
 ## Related projects
 
-What sets DataManifest.jl apart is the **cross-language manifest**: it is one
-member of a multi-language *DataManifest family* built on a shared TOML schema,
-so the same `Datasets.toml` is read by sibling tools in other languages via the
-`_LANG` namespace — a Julia and a Python project can share one data declaration
-without stepping on each other. Configuration stays **declarative**: custom
-logic lives in *references to external Julia code* (`Module:function`) rather
-than code embedded in the config file. A casual user still writes three lines to
-register and fetch a dataset; the rest is there when a project needs it.
+DataManifest.jl is one member of a multi-language *DataManifest family* built
+on a shared TOML schema. The distinguishing feature is the **cross-language
+manifest**: the same `Datasets.toml` is read by sibling tools in other languages
+via the `_LANG` namespace — a Julia and a Python project can share one data
+declaration without stepping on each other. Configuration is **declarative**:
+custom logic lives in *references to external Julia code* (`Module:function`)
+rather than code embedded in the config file.
 
 **The DataManifest family (one manifest, many languages):**
 
@@ -119,7 +118,7 @@ register and fetch a dataset; the rest is there when a project needs it.
 
 ## From the same author
 
-A small toolkit for a Markdown-first scientific workflow.
+A few related tools I maintain, useful in a Markdown-based scientific workflow.
 
 **Scientific writing & data**
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A few related tools I maintain, useful in a Markdown-based scientific workflow.
 
 **Scientific writing & data**
 
-- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and submit them to any journal (Markdown → LaTeX/PDF).
+- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and convert them to journal-ready LaTeX/PDF.
 - [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
 - [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,6 +1,6 @@
 # Produce-or-load caching (`@cached`)
 
-The [README](../README.md#produce-or-load-caching-cached) shows the short
+The [README](https://github.com/awi-esc/DataManifest.jl/blob/main/README.md#produce-or-load-caching-cached) shows the short
 version; this page is the full behaviour of the `@cached` layer.
 
 Beyond *fetching* declared datasets, DataManifest can *produce-or-load* — cache the result

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Be sure you checked the [README](/README.md) first.
+Be sure you checked the [README](https://github.com/awi-esc/DataManifest.jl/blob/main/README.md) first.
 
 ## Working from an existing data "manifest" `Datasets.toml`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ A few related tools I maintain, useful in a Markdown-based scientific workflow.
 
 **Scientific writing & data**
 
-- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and submit them to any journal (Markdown → LaTeX/PDF).
+- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and convert them to journal-ready LaTeX/PDF.
 - [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
 - [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+<!--
+  Home page. The feature bullets are pulled straight from README.md (single
+  source of truth) via the include-markdown plugin; everything else links into
+  the guide.
+-->
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/perrette/datamanifest.toml/main/design/logo/lockup-dark.svg">
+    <img src="https://raw.githubusercontent.com/perrette/datamanifest.toml/main/design/logo/lockup.svg" alt="DataManifest.jl" height="76">
+  </picture>
+</p>
+
+# DataManifest.jl
+
+Keep track of the datasets used in a scientific project.
+
+{%
+  include-markdown "../README.md"
+  start="<!-- intro-start -->"
+  end="<!-- intro-end -->"
+%}
+
+## Get started
+
+```julia
+using Pkg
+Pkg.add("DataManifest")
+```
+
+```julia
+using DataManifest
+DataManifest.add("https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"; name="co2")
+path = get_dataset_path("co2")
+```
+
+- **[Installation](installation.md)** — the package, optional loaders, the Python CLI sibling.
+- **[Quick start](quickstart.md)** — your first dataset, the file-less database.
+- **[Documentation walkthrough](doc.md)** — every feature, end to end.
+- **[API reference](api.md)** — every function and field.
+
+## Guides
+
+- [Produce-or-load caching (`@cached`)](caching.md) — cache expensive results, keyed by parameters.
+- [Per-language bindings](language-bindings.md) — `_LANG`, fetch/load ladders, `lazy_access`, migration.
+- [Storage model](storage.md) — where data lands, `$`-symbols, read pools, the state file.
+- [Manage your data from the shell](shell.md) — the Python `datamanifest` CLI over the same manifest.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,18 @@ path = get_dataset_path("co2")
 - [Per-language bindings](language-bindings.md) — `_LANG`, fetch/load ladders, `lazy_access`, migration.
 - [Storage model](storage.md) — where data lands, `$`-symbols, read pools, the state file.
 - [Manage your data from the shell](shell.md) — the Python `datamanifest` CLI over the same manifest.
+
+## From the same author
+
+A small toolkit for a Markdown-first scientific workflow.
+
+**Scientific writing & data**
+
+- [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and submit them to any journal (Markdown → LaTeX/PDF).
+- [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
+- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
+
+**Voice helpers** — handy for dictating and proofreading drafts by ear
+
+- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation (Whisper).
+- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader (Kokoro / Piper).

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ path = get_dataset_path("co2")
 
 ## From the same author
 
-A small toolkit for a Markdown-first scientific workflow.
+A few related tools I maintain, useful in a Markdown-based scientific workflow.
 
 **Scientific writing & data**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,15 +47,15 @@ path = get_dataset_path("co2")
 
 ## From the same author
 
-A few related tools I maintain, useful in a Markdown-based scientific workflow.
+A few other open-source tools I maintain.
 
 **Scientific writing & data**
 
 - [**texmark**](https://perrette.github.io/texmark/) — write scientific articles in Markdown and convert them to journal-ready LaTeX/PDF.
 - [**papers**](https://perrette.github.io/papers/) — command-line BibTeX bibliography and PDF library manager.
-- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec and the [DataManifest.jl](https://awi-esc.github.io/DataManifest.jl/) Julia port.)*
+- [**datamanifest**](https://perrette.github.io/datamanifest/) — declarative, reproducible dataset management. *(See also the [datamanifest.toml](https://perrette.github.io/datamanifest.toml/) format spec.)*
 
-**Voice helpers** — handy for dictating and proofreading drafts by ear
+**Speech to Text (dictate) and Text to Speech (read-aloud) tools**
 
-- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation (Whisper).
-- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader (Kokoro / Piper).
+- [**scribe**](https://perrette.github.io/scribe/) — speech-to-text dictation.
+- [**bard**](https://perrette.github.io/bard/) — text-to-speech reader.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,41 @@
+# Installation
+
+`DataManifest.jl` is a registered Julia package:
+
+```julia
+using Pkg
+Pkg.add("DataManifest")
+```
+
+Bleeding edge, straight from the repository:
+
+```julia
+Pkg.add(url="https://github.com/awi-esc/DataManifest.jl")
+```
+
+It requires Julia 1.10 or newer.
+
+`DataManifest.jl` is still actively developed, with breaking changes until
+v1.0.0 is reached.
+
+## Optional dependencies
+
+The core package downloads, verifies, extracts and caches data with no extra
+dependencies. Built-in *loaders* for specific formats (CSV, Parquet, NetCDF,
+…) use optional packages and only kick in once you add them to your project —
+e.g. `Pkg.add("CSV")` to enable the `csv` loader. A loader that needs a package
+you have not installed errors with an explicit "add Package" message rather than
+failing silently.
+
+## The Python sibling (CLI)
+
+`DataManifest.jl` ships no command-line interface of its own. The manifest
+format is [shared across languages](https://github.com/perrette/datamanifest.toml),
+and the [Python implementation](https://github.com/perrette/datamanifest)
+brings a full `datamanifest` CLI that manages the *same* `Datasets.toml`:
+
+```bash
+pip install datamanifestpy
+```
+
+See [Manage your data from the shell](shell.md) for the available commands.

--- a/docs/language-bindings.md
+++ b/docs/language-bindings.md
@@ -2,7 +2,7 @@
 
 Custom fetch and load logic lives in a dedicated `_LANG` namespace, so a single
 manifest can serve multiple language implementations without conflicts. The
-[README](../README.md#one-manifest-several-languages) shows the short version;
+[README](https://github.com/awi-esc/DataManifest.jl/blob/main/README.md#one-manifest-several-languages) shows the short version;
 this page is the full behaviour. Bindings are `module:function` references —
 never inline code (the snippets below are drawn from the spec's
 [`examples/datasets.toml`](https://github.com/perrette/datamanifest.toml/blob/main/examples/datasets.toml)):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,61 @@
+# Quick start
+
+In an activated project (`using Pkg; Pkg.activate(...)`):
+
+```julia
+using DataManifest
+
+DataManifest.add("https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"; name="co2")
+path = get_dataset_path("co2")   # resolves under datasets_dir, by default ./datasets/<key>
+```
+
+The `add` downloaded the Mauna Loa CO₂ record and wrote one entry to
+`Datasets.toml` next to your `Project.toml` — a plain TOML file you can read and
+edit by hand, byte-identical to what the sibling Python tool writes:
+
+```toml
+[co2]
+sha256 = "0058b3788040b5c27b2b5c1dd6d26226b7e4deef85e34c153e64806c37df7c75"
+uri = "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"
+```
+
+**Commit `Datasets.toml`** — it's the recipe (what to fetch and how). The
+downloaded data and a local `.datamanifest-state.toml` (which records *where*
+each file landed on this machine) stay git-ignored. A collaborator runs
+`download_datasets()` to materialize everything.
+
+## Being explicit about the database
+
+To be explicit instead of relying on the activated project, construct a
+`Database` yourself:
+
+```julia
+db = Database("Datasets.toml", "my-data-folder")
+DataManifest.add(db, "https://…"; name="…")
+path = get_dataset_path(db, "co2")
+```
+
+## File-less database
+
+For library code that wants checksummed downloads into a folder it controls —
+an OS-appropriate data dir, say — a **file-less database** skips the manifest
+entirely: no `Datasets.toml`, no state file, nothing written but the data. The
+folder accepts the same `$`-symbols as the storage model, e.g. `$user_data_dir`
+or `$user_cache_dir` (`raw"…"` keeps Julia from interpolating the `$`):
+
+```julia
+db = Database(datasets_folder=raw"$user_data_dir/mylib", persist=false)
+DataManifest.add(db, "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_annmean_mlo.csv"; name="co2")
+path = get_dataset_path(db, "co2")   # → ~/.local/share/mylib/gml.noaa.gov/…/co2_annmean_mlo.csv
+```
+
+With a loader declared for the dataset (or its format), `load_dataset("co2")`
+returns the loaded object directly — see [per-language bindings](language-bindings.md).
+
+## Next steps
+
+- [The long-form walkthrough](doc.md) — every feature, end to end.
+- [Produce-or-load caching (`@cached`)](caching.md) — cache expensive results.
+- [Per-language bindings](language-bindings.md) — `_LANG`, ladders, `lazy_access`.
+- [Storage model](storage.md) — where data lands, read pools, the state file.
+- [API reference](api.md) — every function and field.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# Pin below MkDocs 2.0: that release drops the plugin/theme/config system
+# with no migration path and is incompatible with Material for MkDocs.
+# The 1.x line is stable and is what Material targets.
+mkdocs>=1.5,<2
+mkdocs-material>=9.5
+mkdocs-include-markdown-plugin>=6.0

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -1,0 +1,31 @@
+# Manage your data from the shell
+
+DataManifest.jl ships no CLI of its own — it doesn't need one. The manifest is
+language-neutral, and the Python implementation's **`datamanifest`** CLI manages
+the same file (it auto-detects `Datasets.toml`): everything around the data —
+adding, listing, verifying, repairing, syncing — works from the shell, without
+touching your Julia code.
+
+```bash
+pip install datamanifestpy
+```
+
+```bash
+datamanifest list                 # what's tracked, and where it lives
+datamanifest add https://host/path/file.nc
+datamanifest verify               # re-check every checksum
+datamanifest refresh --scan       # repair: reassociate data found on disk
+datamanifest push co2 user@hpc    # rsync a dataset to another machine
+datamanifest storage              # where data goes on this host
+```
+
+See the [Python README](https://github.com/perrette/datamanifest#readme) for
+the use cases and the [CLI reference](https://github.com/perrette/datamanifest/blob/main/docs/cli.md)
+for every command.
+
+## Cross-language fetch
+
+The two tools also cooperate at fetch time: a dataset whose fetcher is written
+in Python is materialized by delegating to this same CLI (and the Python tool
+can delegate to Julia in turn) — see
+[cross-language fetch](language-bindings.md#the-ladders).

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,6 +1,6 @@
 # Storage model and the state file
 
-The [README](../README.md#put-data-where-you-want-it) shows the short version;
+The [README](https://github.com/awi-esc/DataManifest.jl/blob/main/README.md#put-data-where-you-want-it) shows the short version;
 this page is the full storage reference: the two folder fields, `$`-symbols and
 their resolution ladder, per-dataset overrides, read pools, and the state file
 with its maintenance surface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: DataManifest.jl
+site_description: Keep track of the datasets used in a scientific project — declare, download, verify, cache, share
+site_url: https://awi-esc.github.io/DataManifest.jl/
+repo_url: https://github.com/awi-esc/DataManifest.jl
+repo_name: awi-esc/DataManifest.jl
+edit_uri: edit/main/
+
+# All narrative content already lives as Markdown in docs/ and README.md.
+# Nothing is duplicated here: the homepage pulls the README in via the
+# include-markdown plugin, and every other page is an existing docs/*.md file.
+docs_dir: docs
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+
+plugins:
+  - search
+  - include-markdown
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: installation.md
+      - Quick start: quickstart.md
+  - Guides:
+      - Walkthrough: doc.md
+      - Produce-or-load caching: caching.md
+      - Per-language bindings: language-bindings.md
+      - Storage model: storage.md
+      - Manage your data from the shell: shell.md
+  - Reference:
+      - API: api.md


### PR DESCRIPTION
## What

Sets up an MkDocs Material documentation site for DataManifest.jl, mirroring the setup used in the `texmark` project. The site is intended to publish to GitHub Pages at https://awi-esc.github.io/DataManifest.jl/.

## Changes

- **`mkdocs.yml`** — Material theme, `search` + `include-markdown` plugins, pymdownx extensions, and a multi-page nav (Getting started / Guides / Reference).
- **`docs/index.md`** — new homepage. The feature bullets are pulled from `README.md` via the include-markdown plugin, so they have a single source of truth.
- **`docs/installation.md`, `docs/quickstart.md`, `docs/shell.md`** — new pages carrying the user-guide body that previously lived inline in the README.
- **Existing pages reused as-is** (`api.md`, `doc.md`, `caching.md`, `language-bindings.md`, `storage.md`). They are plain Markdown — no Documenter.jl markup — so they render directly. Their relative `../README.md#...` links were rewritten to absolute GitHub URLs so the strict build is clean.
- **`README.md`** — slimmed to a landing page: hero, CI + docs badges, intro bullets between `<!-- intro-start -->` / `<!-- intro-end -->` markers, short install/quickstart, and a Documentation section linking to the published site.
- **`docs/requirements.txt`** — three pinned MkDocs deps (Julia package, so no Python extra).
- **`.github/workflows/docs.yml`** — installs `docs/requirements.txt` and runs `mkdocs gh-deploy --force` on push to `main`.

## Verification

`mkdocs build --strict` passes with zero warnings (only the Material "MkDocs 2.0" informational banner is printed).

## Notes for reviewers

- Pages was **not** enabled and nothing was pushed to `main` directly, since this is a shared org repo. Merging this PR will trigger the `docs` workflow, which creates the `gh-pages` branch; an admin then needs to enable Pages (source = `gh-pages`) once.
- `.github/workflows/docs.yml` had to be force-added: the repo's `.gitignore` contains a broad `workflows/` rule (for autonomous-roadmap local artifacts) that also matches `.github/workflows/`. The existing `ci.yaml` / `TagBot.yaml` are tracked the same way (committed before that rule existed). `.gitignore` itself was left untouched.